### PR TITLE
Import latitude/longitude from CallingAllPapers

### DIFF
--- a/app/CallingAllPapers/ConferenceImporter.php
+++ b/app/CallingAllPapers/ConferenceImporter.php
@@ -33,6 +33,8 @@ class ConferenceImporter
         $conference->url = trim($event->eventUri);
         $conference->cfp_url = $event->uri;
         $conference->location = $event->location;
+        $conference->latitude = $event->latitude;
+        $conference->longitude = $event->longitude;
         $conference->starts_at = self::carbonFromIso($event->dateEventStart);
         $conference->ends_at = self::carbonFromIso($event->dateEventEnd);
         $conference->cfp_starts_at = self::carbonFromIso($event->dateCfpStart);


### PR DESCRIPTION
With #280 these fields are tracked on the conference; might as well import them from CallingAllPapers even though [they're not completely reliable](https://github.com/tightenco/symposium/pull/261#issuecomment-548232112)