### PR TITLE
Bump league/flysystem from 1.1.3 to 1.1.4

### DIFF
--- a/app/Http/Controllers/ConferencesController.php
+++ b/app/Http/Controllers/ConferencesController.php
@@ -57,13 +57,13 @@ class ConferencesController extends BaseController
                 $query->orderBy('starts_at');
                 break;
             case 'opening_next':
-                $query->orderByRaw('ISNULL(cfp_ends_at), cfp_ends_at ASC');
+                $query->orderByRaw('cfp_ends_at IS NULL, cfp_ends_at ASC');
                 break;
             case 'closing_next':
                 // pass through
             default:
-                $query->orderByRaw('ISNULL(cfp_ends_at), cfp_ends_at ASC'); 
-            break;
+                $query->orderByRaw('cfp_ends_at IS NULL, cfp_ends_at ASC');
+                break;
         }
 
         return view('conferences.index', [
@@ -121,7 +121,7 @@ class ConferencesController extends BaseController
     {
         $conference = Conference::findOrFail($id);
 
-        if ($conference->author_id !== auth()->id() && !auth()->user()->isAdmin()) {
+        if ($conference->author_id !== auth()->id() && ! auth()->user()->isAdmin()) {
             Log::error('User ' . auth()->user()->id . " tried to edit a conference they don't own.");
 
             return redirect('/');
@@ -139,7 +139,7 @@ class ConferencesController extends BaseController
         // @todo Update this to use ACL... gosh this app is old...
         $conference = Conference::findOrFail($id);
 
-        if ($conference->author_id !== auth()->id() && !auth()->user()->isAdmin()) {
+        if ($conference->author_id !== auth()->id() && ! auth()->user()->isAdmin()) {
             Log::error('User ' . auth()->user()->id . " tried to edit a conference they don't own.");
 
             return redirect('/');

--- a/composer.lock
+++ b/composer.lock
@@ -2811,16 +2811,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "9be3b16c877d477357c015cec057548cf9b2a14a"
+                "reference": "f3ad69181b8afed2c9edf7be5a2918144ff4ea32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/9be3b16c877d477357c015cec057548cf9b2a14a",
-                "reference": "9be3b16c877d477357c015cec057548cf9b2a14a",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/f3ad69181b8afed2c9edf7be5a2918144ff4ea32",
+                "reference": "f3ad69181b8afed2c9edf7be5a2918144ff4ea32",
                 "shasum": ""
             },
             "require": {
@@ -2836,7 +2836,6 @@
                 "phpunit/phpunit": "^8.5.8"
             },
             "suggest": {
-                "ext-fileinfo": "Required for MimeType",
                 "ext-ftp": "Allows you to use FTP server storage",
                 "ext-openssl": "Allows you to use FTPS server storage",
                 "league/flysystem-aws-s3-v2": "Allows you to use S3 storage with AWS SDK v2",
@@ -2894,7 +2893,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/1.x"
+                "source": "https://github.com/thephpleague/flysystem/tree/1.1.4"
             },
             "funding": [
                 {
@@ -2902,7 +2901,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2020-08-23T07:39:11+00:00"
+            "time": "2021-06-23T21:56:05+00:00"
         },
         {
             "name": "league/mime-type-detection",

--- a/database/factories/Factory.php
+++ b/database/factories/Factory.php
@@ -92,7 +92,7 @@ $factory->define(App\Bio::class, function (Faker $faker) {
         'user_id' => function () {
             return factory(App\User::class)->create()->id;
         },
-        'nickname' => 'short',
+        'nickname' => $faker->word,
         'body' => $faker->sentence(),
     ];
 });

--- a/tests/PublicSpeakerProfileTest.php
+++ b/tests/PublicSpeakerProfileTest.php
@@ -302,11 +302,11 @@ class PublicSpeakerProfileTest extends IntegrationTestCase
             'enable_profile' => true,
         ]);
 
-        $bio = factory(Bio::class)->create();
+        $bio = factory(Bio::class)->create(['nickname' => 'test bio']);
         $bio->public = true;
         $user2->bios()->save($bio);
 
         $this->visit(route('speakers-public.show', [$user->profile_slug]))
-            ->dontSee($bio->nickname);
+            ->dontSee('test bio');
     }
 }


### PR DESCRIPTION
Bumps `league/flysystem` from 1.1.3 to 1.1.4 for critical security update.

This PR also fixes failing tests.