### PR TITLE
fix conference speakers alignment

### DIFF
--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -26,7 +26,7 @@
         </div>
         <div class="flex flex-wrap">
             <div class="w-full px-6 pb-6 mb-8 md:w-1/2 lg:w-1/3 lg:pl-0 md:pb-0">
-                @svg('icon_tracktalks', 'mx-auto md:ml-3 w-16 h-16')
+                @svg('icon_tracktalks', 'mx-auto md:ml-3 w-16')
                 <div class="mt-5 mb-4 font-sans text-2xl font-semibold text-center md:text-left">Track talks</div>
                 <div class="font-sans text-xl">Track all of your talks, each with one or more versions and each version with a full revision history.</div>
             </div>


### PR DESCRIPTION
- Fix conference speakers alignment (First block "Track talks" is a bit higher than its siblings)

# Before
![Screenshot from 2021-09-11 11-40-57](https://user-images.githubusercontent.com/60013703/132945112-a2d0ac3d-2079-4f19-9ef3-d679039a1795.png)

# After
![Screenshot from 2021-09-11 11-41-58](https://user-images.githubusercontent.com/60013703/132945130-58050a1a-50f7-4f80-9fd9-cec1c4f27f30.png)
