### PR TITLE
Hotfix: Fix broken API routes

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,13 @@
 
 namespace Database\Seeders;
 
+use Database\Seeders\AcceptanceSeeder;
+use Database\Seeders\BiosSeeder;
+use Database\Seeders\ConferencesSeeder;
+use Database\Seeders\RejectionSeeder;
+use Database\Seeders\SubmissionsSeeder;
+use Database\Seeders\TalksSeeder;
+use Database\Seeders\UsersSeeder;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
@@ -21,13 +28,15 @@ class DatabaseSeeder extends Seeder
             DB::statement('SET FOREIGN_KEY_CHECKS = 0');
         }
 
-        $this->call('UsersSeeder');
-        $this->call('TalksSeeder');
-        $this->call('BiosSeeder');
-        $this->call('ConferencesSeeder');
-        $this->call('SubmissionsSeeder');
-        $this->call('AcceptanceSeeder');
-        $this->call('RejectionSeeder');
+        $this->call([
+            UsersSeeder::class,
+            TalksSeeder::class,
+            BiosSeeder::class,
+            ConferencesSeeder::class,
+            SubmissionsSeeder::class,
+            AcceptanceSeeder::class,
+            RejectionSeeder::class,
+        ]);
 
         if (! app()->environment('testing')) {
             DB::statement('SET FOREIGN_KEY_CHECKS = 1');

--- a/database/seeders/UsersSeeder.php
+++ b/database/seeders/UsersSeeder.php
@@ -16,8 +16,8 @@ class UsersSeeder extends Seeder
             'email' => 'matt@savemyproposals.com',
         ]);
 
-        User::factory()->create([
+        User::factory()->count(10)->create([
             'is_featured' => rand(0, 1),
-        ], 10);
+        ]);
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,6 +17,9 @@
         <testsuite name="Feature">
             <directory suffix="Test.php">./tests/Feature</directory>
         </testsuite>
+        <testsuite name="Api">
+            <directory suffix="Test.php">./tests/Api</directory>
+        </testsuite>
     </testsuites>
     <coverage processUncoveredFiles="true">
         <include>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,11 +1,11 @@
 <?php
 
-use App\Http\Controllers\BiosController;
-use App\Http\Controllers\ConferencesController;
-use App\Http\Controllers\MeController;
-use App\Http\Controllers\TalksController;
-use App\Http\Controllers\UserBiosController;
-use App\Http\Controllers\UserTalksController;
+use App\Http\Controllers\Api\BiosController;
+use App\Http\Controllers\Api\ConferencesController;
+use App\Http\Controllers\Api\MeController;
+use App\Http\Controllers\Api\TalksController;
+use App\Http\Controllers\Api\UserBiosController;
+use App\Http\Controllers\Api\UserTalksController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:api')->group(function () {


### PR DESCRIPTION
This PR fixes broken API routes that were not tested after the Shift upgrade to Laravel 8.  The following updates have been made:
- The `DatabaseSeeder` now imports all of the seeder classes to account for namespacing
- The `UserSeeder` now calls the `count` method
- A new `Api` suite has been added to `phpunit.xml`
- The `Api` namespace has been added to the controllers imported for the routes defined in `routes/api.php`

This PR is made directly to `main` as a hotfix.