### PR TITLE
Upgrade Tailwind to version 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
                 "vform": "^1.0.0"
             },
             "devDependencies": {
-                "@tailwindcss/custom-forms": "^0.2.1",
+                "@tailwindcss/forms": "^0.5.0",
+                "autoprefixer": "^10.4.4",
                 "axios": ">=0.26.1",
                 "bootstrap-sass": ">=3.4.1",
                 "browser-sync": "^2.26.7",
@@ -21,11 +22,11 @@
                 "laravel-mix": "^6.0.25",
                 "laravel-mix-purgecss": "^6.0.0",
                 "lodash": "^4.17.15",
-                "postcss": "^8.2.8",
+                "postcss": "^8.4.12",
                 "resolve-url-loader": "^4.0.0",
                 "sass": "^1.35.1",
                 "sass-loader": "^12.1.0",
-                "tailwindcss": "^1.5.1",
+                "tailwindcss": "^3.0.24",
                 "vue": "^2.6.7",
                 "vue-loader": "^15.9.7",
                 "vue-template-compiler": "^2.6.10"
@@ -1875,18 +1876,16 @@
             "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
             "dev": true
         },
-        "node_modules/@tailwindcss/custom-forms": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/custom-forms/-/custom-forms-0.2.1.tgz",
-            "integrity": "sha512-XdP5XY6kxo3x5o50mWUyoYWxOPV16baagLoZ5uM41gh6IhXzhz/vJYzqrTb/lN58maGIKlpkxgVsQUNSsbAS3Q==",
+        "node_modules/@tailwindcss/forms": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.0.tgz",
+            "integrity": "sha512-KzWugryEBFkmoaYcBE18rs6gthWCFHHO7cAZm2/hv3hwD67AzwP7udSCa22E7R1+CEJL/FfhYsJWrc0b1aeSzw==",
             "dev": true,
             "dependencies": {
-                "lodash": "^4.17.11",
-                "mini-svg-data-uri": "^1.0.3",
-                "traverse": "^0.6.6"
+                "mini-svg-data-uri": "^1.2.3"
             },
             "peerDependencies": {
-                "tailwindcss": "^1.0"
+                "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
             }
         },
         "node_modules/@trysound/sax": {
@@ -2749,6 +2748,12 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/arg": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
+            "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
+            "dev": true
+        },
         "node_modules/array-flatten": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -3592,16 +3597,6 @@
             "integrity": "sha512-NAyuk1DnCotRaDZIS5kJ4sptgkwOeYqElird10yziN5JBuwYOGkOTguhNcPn5g344IfylZecxNYZAVXgv19p5Q==",
             "dev": true
         },
-        "node_modules/color": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-            "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.4"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3620,41 +3615,10 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
-        "node_modules/color-string": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
-            "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "^1.0.0",
-                "simple-swizzle": "^0.2.2"
-            }
-        },
-        "node_modules/color/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/color/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
-        },
         "node_modules/colord": {
             "version": "2.9.2",
             "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
             "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
-            "dev": true
-        },
-        "node_modules/colorette": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-            "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
             "dev": true
         },
         "node_modules/colors": {
@@ -4175,12 +4139,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/css-unit-converter": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
-            "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
-            "dev": true
-        },
         "node_modules/css-what": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -4406,6 +4364,12 @@
             "engines": {
                 "node": ">= 0.8.0"
             }
+        },
+        "node_modules/didyoumean": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+            "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+            "dev": true
         },
         "node_modules/diffie-hellman": {
             "version": "5.0.3",
@@ -5109,9 +5073,9 @@
             "dev": true
         },
         "node_modules/fast-glob": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
-            "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
+            "version": "3.2.11",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
             "dev": true,
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -5121,7 +5085,7 @@
                 "micromatch": "^4.0.4"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=8.6.0"
             }
         },
         "node_modules/fast-json-stable-stringify": {
@@ -5804,15 +5768,6 @@
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
         },
-        "node_modules/html-tags": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
-            "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/htmlparser2": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
@@ -6010,18 +5965,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/import-cwd": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
-            "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
-            "dev": true,
-            "dependencies": {
-                "import-from": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -6036,27 +5979,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/import-from": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
-            "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
-            "dev": true,
-            "dependencies": {
-                "resolve-from": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/import-from/node_modules/resolve-from": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/import-local": {
@@ -6137,9 +6059,9 @@
             "dev": true
         },
         "node_modules/is-core-module": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-            "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+            "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
             "dev": true,
             "dependencies": {
                 "has": "^1.0.3"
@@ -6182,9 +6104,9 @@
             }
         },
         "node_modules/is-glob": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
             "dependencies": {
                 "is-extglob": "^2.1.1"
@@ -6536,9 +6458,9 @@
             }
         },
         "node_modules/lilconfig": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
-            "integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
+            "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
             "dev": true,
             "engines": {
                 "node": ">=10"
@@ -6702,12 +6624,6 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-            "dev": true
-        },
-        "node_modules/lodash.toarray": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-            "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
             "dev": true
         },
         "node_modules/lodash.uniq": {
@@ -6974,9 +6890,9 @@
             }
         },
         "node_modules/mini-svg-data-uri": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.3.3.tgz",
-            "integrity": "sha512-+fA2oRcR1dJI/7ITmeQJDrYWks0wodlOz0pAEhKYJ2IVc1z0AnwJUsKY2fzFmPAM3Jo9J0rBx8JAA9QQSJ5PuA==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+            "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
             "dev": true,
             "bin": {
                 "mini-svg-data-uri": "cli.js"
@@ -7084,15 +7000,6 @@
             "dependencies": {
                 "lower-case": "^2.0.2",
                 "tslib": "^2.0.3"
-            }
-        },
-        "node_modules/node-emoji": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-            "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
-            "dev": true,
-            "dependencies": {
-                "lodash.toarray": "^4.4.0"
             }
         },
         "node_modules/node-forge": {
@@ -7221,12 +7128,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/normalize.css": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
-            "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
-            "dev": true
-        },
         "node_modules/npm-run-path": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -7251,12 +7152,6 @@
                 "url": "https://github.com/fb55/nth-check?sponsor=1"
             }
         },
-        "node_modules/num2fraction": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-            "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
-            "dev": true
-        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7267,9 +7162,9 @@
             }
         },
         "node_modules/object-hash": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-            "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+            "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
             "dev": true,
             "engines": {
                 "node": ">= 6"
@@ -7826,228 +7721,32 @@
                 "postcss": "^8.2.15"
             }
         },
-        "node_modules/postcss-functions": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
-            "integrity": "sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.2",
-                "object-assign": "^4.1.1",
-                "postcss": "^6.0.9",
-                "postcss-value-parser": "^3.3.0"
-            }
-        },
-        "node_modules/postcss-functions/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-functions/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-functions/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/postcss-functions/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
-        },
-        "node_modules/postcss-functions/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-functions/node_modules/postcss": {
-            "version": "6.0.23",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-            "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^2.4.1",
-                "source-map": "^0.6.1",
-                "supports-color": "^5.4.0"
-            },
-            "engines": {
-                "node": ">=4.0.0"
-            }
-        },
-        "node_modules/postcss-functions/node_modules/postcss-value-parser": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-            "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-            "dev": true
-        },
-        "node_modules/postcss-functions/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/postcss-functions/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/postcss-js": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-2.0.3.tgz",
-            "integrity": "sha512-zS59pAk3deu6dVHyrGqmC3oDXBdNdajk4k1RyxeVXCrcEDBUBHoIhE4QTsmhxgzXxsaqFDAkUZfmMa5f/N/79w==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz",
+            "integrity": "sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==",
             "dev": true,
             "dependencies": {
-                "camelcase-css": "^2.0.1",
-                "postcss": "^7.0.18"
-            }
-        },
-        "node_modules/postcss-js/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
+                "camelcase-css": "^2.0.1"
             },
             "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-js/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-js/node_modules/chalk/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-js/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/postcss-js/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
-        },
-        "node_modules/postcss-js/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-js/node_modules/postcss": {
-            "version": "7.0.36",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
+                "node": "^12 || ^14 || >= 16"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/postcss/"
-            }
-        },
-        "node_modules/postcss-js/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/postcss-js/node_modules/supports-color": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-            "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
             },
-            "engines": {
-                "node": ">=6"
+            "peerDependencies": {
+                "postcss": "^8.3.3"
             }
         },
         "node_modules/postcss-load-config": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.0.tgz",
-            "integrity": "sha512-ipM8Ds01ZUophjDTQYSVP70slFSYg3T0/zyfII5vzhN6V57YSxMgG5syXuwi5VtS8wSf3iL30v0uBdoIVx4Q0g==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+            "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
             "dev": true,
             "dependencies": {
-                "import-cwd": "^3.0.0",
-                "lilconfig": "^2.0.3",
+                "lilconfig": "^2.0.5",
                 "yaml": "^1.10.2"
             },
             "engines": {
@@ -8058,9 +7757,13 @@
                 "url": "https://opencollective.com/postcss/"
             },
             "peerDependencies": {
+                "postcss": ">=8.0.9",
                 "ts-node": ">=9.0.0"
             },
             "peerDependenciesMeta": {
+                "postcss": {
+                    "optional": true
+                },
                 "ts-node": {
                     "optional": true
                 }
@@ -8270,114 +7973,22 @@
             }
         },
         "node_modules/postcss-nested": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.3.tgz",
-            "integrity": "sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
+            "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
             "dev": true,
             "dependencies": {
-                "postcss": "^7.0.32",
-                "postcss-selector-parser": "^6.0.2"
-            }
-        },
-        "node_modules/postcss-nested/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
+                "postcss-selector-parser": "^6.0.6"
             },
             "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-nested/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-nested/node_modules/chalk/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-nested/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/postcss-nested/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
-        },
-        "node_modules/postcss-nested/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/postcss-nested/node_modules/postcss": {
-            "version": "7.0.36",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
+                "node": ">=12.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/postcss/"
-            }
-        },
-        "node_modules/postcss-nested/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/postcss-nested/node_modules/supports-color": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-            "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
             },
-            "engines": {
-                "node": ">=6"
+            "peerDependencies": {
+                "postcss": "^8.2.14"
             }
         },
         "node_modules/postcss-normalize-charset": {
@@ -8645,15 +8256,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/pretty-hrtime": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-            "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-            "dev": true,
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/pretty-time": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
@@ -8804,6 +8406,18 @@
                 }
             ]
         },
+        "node_modules/quick-lru": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -8894,22 +8508,6 @@
             "engines": {
                 "node": ">= 0.10"
             }
-        },
-        "node_modules/reduce-css-calc": {
-            "version": "2.1.8",
-            "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
-            "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
-            "dev": true,
-            "dependencies": {
-                "css-unit-converter": "^1.1.1",
-                "postcss-value-parser": "^3.3.0"
-            }
-        },
-        "node_modules/reduce-css-calc/node_modules/postcss-value-parser": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-            "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-            "dev": true
         },
         "node_modules/regenerate": {
             "version": "1.4.2",
@@ -9037,13 +8635,17 @@
             "dev": true
         },
         "node_modules/resolve": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+            "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
             "dev": true,
             "dependencies": {
-                "is-core-module": "^2.2.0",
-                "path-parse": "^1.0.6"
+                "is-core-module": "^2.8.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -9638,21 +9240,6 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "dev": true
         },
-        "node_modules/simple-swizzle": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-            "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-            "dev": true,
-            "dependencies": {
-                "is-arrayish": "^0.3.1"
-            }
-        },
-        "node_modules/simple-swizzle/node_modules/is-arrayish": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-            "dev": true
-        },
         "node_modules/slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -10155,6 +9742,18 @@
                 "node": ">=8"
             }
         },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true,
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/svgo": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
@@ -10186,308 +9785,54 @@
             }
         },
         "node_modules/tailwindcss": {
-            "version": "1.9.6",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.9.6.tgz",
-            "integrity": "sha512-nY8WYM/RLPqGsPEGEV2z63riyQPcHYZUJpAwdyBzVpxQHOHqHE+F/fvbCeXhdF1+TA5l72vSkZrtYCB9hRcwkQ==",
+            "version": "3.0.24",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.24.tgz",
+            "integrity": "sha512-H3uMmZNWzG6aqmg9q07ZIRNIawoiEcNFKDfL+YzOPuPsXuDXxJxB9icqzLgdzKNwjG3SAro2h9SYav8ewXNgig==",
             "dev": true,
             "dependencies": {
-                "@fullhuman/postcss-purgecss": "^2.1.2",
-                "autoprefixer": "^9.4.5",
-                "browserslist": "^4.12.0",
-                "bytes": "^3.0.0",
-                "chalk": "^3.0.0 || ^4.0.0",
-                "color": "^3.1.2",
+                "arg": "^5.0.1",
+                "chokidar": "^3.5.3",
+                "color-name": "^1.1.4",
                 "detective": "^5.2.0",
-                "fs-extra": "^8.0.0",
-                "html-tags": "^3.1.0",
-                "lodash": "^4.17.20",
-                "node-emoji": "^1.8.1",
-                "normalize.css": "^8.0.1",
-                "object-hash": "^2.0.3",
-                "postcss": "^7.0.11",
-                "postcss-functions": "^3.0.0",
-                "postcss-js": "^2.0.0",
-                "postcss-nested": "^4.1.1",
-                "postcss-selector-parser": "^6.0.0",
-                "postcss-value-parser": "^4.1.0",
-                "pretty-hrtime": "^1.0.3",
-                "reduce-css-calc": "^2.1.6",
-                "resolve": "^1.14.2"
+                "didyoumean": "^1.2.2",
+                "dlv": "^1.1.3",
+                "fast-glob": "^3.2.11",
+                "glob-parent": "^6.0.2",
+                "is-glob": "^4.0.3",
+                "lilconfig": "^2.0.5",
+                "normalize-path": "^3.0.0",
+                "object-hash": "^3.0.0",
+                "picocolors": "^1.0.0",
+                "postcss": "^8.4.12",
+                "postcss-js": "^4.0.0",
+                "postcss-load-config": "^3.1.4",
+                "postcss-nested": "5.0.6",
+                "postcss-selector-parser": "^6.0.10",
+                "postcss-value-parser": "^4.2.0",
+                "quick-lru": "^5.1.1",
+                "resolve": "^1.22.0"
             },
             "bin": {
                 "tailwind": "lib/cli.js",
                 "tailwindcss": "lib/cli.js"
             },
             "engines": {
-                "node": ">=8.9.0"
+                "node": ">=12.13.0"
+            },
+            "peerDependencies": {
+                "postcss": "^8.0.9"
             }
         },
-        "node_modules/tailwindcss/node_modules/@fullhuman/postcss-purgecss": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.3.0.tgz",
-            "integrity": "sha512-qnKm5dIOyPGJ70kPZ5jiz0I9foVOic0j+cOzNDoo8KoCf6HjicIZ99UfO2OmE7vCYSKAAepEwJtNzpiiZAh9xw==",
+        "node_modules/tailwindcss/node_modules/glob-parent": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "dependencies": {
-                "postcss": "7.0.32",
-                "purgecss": "^2.3.0"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/@fullhuman/postcss-purgecss/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
+                "is-glob": "^4.0.3"
             },
             "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/@fullhuman/postcss-purgecss/node_modules/chalk/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/@fullhuman/postcss-purgecss/node_modules/postcss": {
-            "version": "7.0.32",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-            "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            },
-            "funding": {
-                "type": "tidelift",
-                "url": "https://tidelift.com/funding/github/npm/postcss"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/ansi-styles": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^1.9.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/autoprefixer": {
-            "version": "9.8.6",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
-            "integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
-            "dev": true,
-            "dependencies": {
-                "browserslist": "^4.12.0",
-                "caniuse-lite": "^1.0.30001109",
-                "colorette": "^1.2.1",
-                "normalize-range": "^0.1.2",
-                "num2fraction": "^1.2.2",
-                "postcss": "^7.0.32",
-                "postcss-value-parser": "^4.1.0"
-            },
-            "bin": {
-                "autoprefixer": "bin/autoprefixer"
-            },
-            "funding": {
-                "type": "tidelift",
-                "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/color-convert": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "1.1.3"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/color-name": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-            "dev": true
-        },
-        "node_modules/tailwindcss/node_modules/commander": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-            "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-            "dev": true,
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/fs-extra": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-            "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-            "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.2.0",
-                "jsonfile": "^4.0.0",
-                "universalify": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=6 <7 || >=8"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/has-flag": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-            "dev": true,
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/jsonfile": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-            "dev": true,
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/postcss": {
-            "version": "7.0.36",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-            "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/postcss/"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/postcss/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/postcss/node_modules/chalk/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/purgecss": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-2.3.0.tgz",
-            "integrity": "sha512-BE5CROfVGsx2XIhxGuZAT7rTH9lLeQx/6M0P7DTXQH4IUc3BBzs9JUzt4yzGf3JrH9enkeq6YJBe9CTtkm1WmQ==",
-            "dev": true,
-            "dependencies": {
-                "commander": "^5.0.0",
-                "glob": "^7.0.0",
-                "postcss": "7.0.32",
-                "postcss-selector-parser": "^6.0.2"
-            },
-            "bin": {
-                "purgecss": "bin/purgecss"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/purgecss/node_modules/chalk": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/purgecss/node_modules/chalk/node_modules/supports-color": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/purgecss/node_modules/postcss": {
-            "version": "7.0.32",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-            "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-            "dev": true,
-            "dependencies": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-            },
-            "engines": {
-                "node": ">=6.0.0"
-            },
-            "funding": {
-                "type": "tidelift",
-                "url": "https://tidelift.com/funding/github/npm/postcss"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/source-map": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/tailwindcss/node_modules/supports-color": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-            "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=6"
+                "node": ">=10.13.0"
             }
         },
         "node_modules/tapable": {
@@ -10729,12 +10074,6 @@
             "engines": {
                 "node": ">=0.6"
             }
-        },
-        "node_modules/traverse": {
-            "version": "0.6.6",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-            "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
-            "dev": true
         },
         "node_modules/tslib": {
             "version": "2.3.0",
@@ -12936,15 +12275,13 @@
             "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
             "dev": true
         },
-        "@tailwindcss/custom-forms": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/@tailwindcss/custom-forms/-/custom-forms-0.2.1.tgz",
-            "integrity": "sha512-XdP5XY6kxo3x5o50mWUyoYWxOPV16baagLoZ5uM41gh6IhXzhz/vJYzqrTb/lN58maGIKlpkxgVsQUNSsbAS3Q==",
+        "@tailwindcss/forms": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.0.tgz",
+            "integrity": "sha512-KzWugryEBFkmoaYcBE18rs6gthWCFHHO7cAZm2/hv3hwD67AzwP7udSCa22E7R1+CEJL/FfhYsJWrc0b1aeSzw==",
             "dev": true,
             "requires": {
-                "lodash": "^4.17.11",
-                "mini-svg-data-uri": "^1.0.3",
-                "traverse": "^0.6.6"
+                "mini-svg-data-uri": "^1.2.3"
             }
         },
         "@trysound/sax": {
@@ -13711,6 +13048,12 @@
                 "picomatch": "^2.0.4"
             }
         },
+        "arg": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.1.tgz",
+            "integrity": "sha512-e0hDa9H2Z9AwFkk2qDlwhoMYE4eToKarchkQHovNdLTCYMHZHeRjI71crOh+dio4K6u1IcwubQqo79Ga4CyAQA==",
+            "dev": true
+        },
         "array-flatten": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
@@ -14382,33 +13725,6 @@
             "integrity": "sha512-NAyuk1DnCotRaDZIS5kJ4sptgkwOeYqElird10yziN5JBuwYOGkOTguhNcPn5g344IfylZecxNYZAVXgv19p5Q==",
             "dev": true
         },
-        "color": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/color/-/color-3.1.3.tgz",
-            "integrity": "sha512-xgXAcTHa2HeFCGLE9Xs/R82hujGtu9Jd9x4NW3T34+OMs7VoPsjwzRczKHvTAHeJwWFwX5j15+MgAppE8ztObQ==",
-            "dev": true,
-            "requires": {
-                "color-convert": "^1.9.1",
-                "color-string": "^1.5.4"
-            },
-            "dependencies": {
-                "color-convert": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-                    "dev": true
-                }
-            }
-        },
         "color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -14424,26 +13740,10 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
-        "color-string": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.5.tgz",
-            "integrity": "sha512-jgIoum0OfQfq9Whcfc2z/VhCNcmQjWbey6qBX0vqt7YICflUmBCh9E9CiQD5GSJ+Uehixm3NUwHVhqUAWRivZg==",
-            "dev": true,
-            "requires": {
-                "color-name": "^1.0.0",
-                "simple-swizzle": "^0.2.2"
-            }
-        },
         "colord": {
             "version": "2.9.2",
             "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
             "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
-            "dev": true
-        },
-        "colorette": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-            "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
             "dev": true
         },
         "colors": {
@@ -14850,12 +14150,6 @@
                 }
             }
         },
-        "css-unit-converter": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
-            "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
-            "dev": true
-        },
         "css-what": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -15020,6 +14314,12 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/dev-ip/-/dev-ip-1.0.1.tgz",
             "integrity": "sha1-p2o+0YVb56ASu4rBbLgPPADcKPA=",
+            "dev": true
+        },
+        "didyoumean": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+            "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
             "dev": true
         },
         "diffie-hellman": {
@@ -15577,9 +14877,9 @@
             "dev": true
         },
         "fast-glob": {
-            "version": "3.2.6",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.6.tgz",
-            "integrity": "sha512-GnLuqj/pvQ7pX8/L4J84nijv6sAnlwvSDpMkJi9i7nPmPxGtRPkBSStfvDW5l6nMdX9VWe+pkKWFTgD+vF2QSQ==",
+            "version": "3.2.11",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+            "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -16088,12 +15388,6 @@
                 }
             }
         },
-        "html-tags": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
-            "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
-            "dev": true
-        },
         "htmlparser2": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
@@ -16233,15 +15527,6 @@
             "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=",
             "dev": true
         },
-        "import-cwd": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-3.0.0.tgz",
-            "integrity": "sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==",
-            "dev": true,
-            "requires": {
-                "import-from": "^3.0.0"
-            }
-        },
         "import-fresh": {
             "version": "3.3.0",
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
@@ -16250,23 +15535,6 @@
             "requires": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
-            }
-        },
-        "import-from": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
-            "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
-            "dev": true,
-            "requires": {
-                "resolve-from": "^5.0.0"
-            },
-            "dependencies": {
-                "resolve-from": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-                    "dev": true
-                }
             }
         },
         "import-local": {
@@ -16329,9 +15597,9 @@
             "dev": true
         },
         "is-core-module": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-            "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+            "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -16356,9 +15624,9 @@
             "dev": true
         },
         "is-glob": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-            "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
@@ -16620,9 +15888,9 @@
             }
         },
         "lilconfig": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.3.tgz",
-            "integrity": "sha512-EHKqr/+ZvdKCifpNrJCKxBTgk5XupZA3y/aCPY9mxfgBzmgh93Mt/WqjjQ38oMxXuvDokaKiM3lAgvSH2sjtHg==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
+            "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
             "dev": true
         },
         "limiter": {
@@ -16755,12 +16023,6 @@
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
             "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-            "dev": true
-        },
-        "lodash.toarray": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-            "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
             "dev": true
         },
         "lodash.uniq": {
@@ -16971,9 +16233,9 @@
             }
         },
         "mini-svg-data-uri": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.3.3.tgz",
-            "integrity": "sha512-+fA2oRcR1dJI/7ITmeQJDrYWks0wodlOz0pAEhKYJ2IVc1z0AnwJUsKY2fzFmPAM3Jo9J0rBx8JAA9QQSJ5PuA==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+            "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
             "dev": true
         },
         "minimalistic-assert": {
@@ -17060,15 +16322,6 @@
             "requires": {
                 "lower-case": "^2.0.2",
                 "tslib": "^2.0.3"
-            }
-        },
-        "node-emoji": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-            "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
-            "dev": true,
-            "requires": {
-                "lodash.toarray": "^4.4.0"
             }
         },
         "node-forge": {
@@ -17172,12 +16425,6 @@
             "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
             "dev": true
         },
-        "normalize.css": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/normalize.css/-/normalize.css-8.0.1.tgz",
-            "integrity": "sha512-qizSNPO93t1YUuUhP22btGOo3chcvDFqFaj2TRybP0DMxkHOCTYwp3n34fel4a31ORXy4m1Xq0Gyqpb5m33qIg==",
-            "dev": true
-        },
         "npm-run-path": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
@@ -17196,12 +16443,6 @@
                 "boolbase": "^1.0.0"
             }
         },
-        "num2fraction": {
-            "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
-            "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
-            "dev": true
-        },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -17209,9 +16450,9 @@
             "dev": true
         },
         "object-hash": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-            "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+            "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
             "dev": true
         },
         "object-keys": {
@@ -17624,191 +16865,22 @@
             "dev": true,
             "requires": {}
         },
-        "postcss-functions": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-functions/-/postcss-functions-3.0.0.tgz",
-            "integrity": "sha1-DpTQFERwCkgd4g3k1V+yZAVkJQ4=",
-            "dev": true,
-            "requires": {
-                "glob": "^7.1.2",
-                "object-assign": "^4.1.1",
-                "postcss": "^6.0.9",
-                "postcss-value-parser": "^3.3.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "6.0.23",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-                    "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
-                    }
-                },
-                "postcss-value-parser": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-                    "dev": true
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
-            }
-        },
         "postcss-js": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-2.0.3.tgz",
-            "integrity": "sha512-zS59pAk3deu6dVHyrGqmC3oDXBdNdajk4k1RyxeVXCrcEDBUBHoIhE4QTsmhxgzXxsaqFDAkUZfmMa5f/N/79w==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.0.tgz",
+            "integrity": "sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==",
             "dev": true,
             "requires": {
-                "camelcase-css": "^2.0.1",
-                "postcss": "^7.0.18"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                            "dev": true,
-                            "requires": {
-                                "has-flag": "^3.0.0"
-                            }
-                        }
-                    }
-                },
-                "color-convert": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "7.0.36",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.2",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^6.1.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
+                "camelcase-css": "^2.0.1"
             }
         },
         "postcss-load-config": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.0.tgz",
-            "integrity": "sha512-ipM8Ds01ZUophjDTQYSVP70slFSYg3T0/zyfII5vzhN6V57YSxMgG5syXuwi5VtS8wSf3iL30v0uBdoIVx4Q0g==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz",
+            "integrity": "sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==",
             "dev": true,
             "requires": {
-                "import-cwd": "^3.0.0",
-                "lilconfig": "^2.0.3",
+                "lilconfig": "^2.0.5",
                 "yaml": "^1.10.2"
             }
         },
@@ -17939,93 +17011,12 @@
             }
         },
         "postcss-nested": {
-            "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-4.2.3.tgz",
-            "integrity": "sha512-rOv0W1HquRCamWy2kFl3QazJMMe1ku6rCFoAAH+9AcxdbpDeBr6k968MLWuLjvjMcGEip01ak09hKOEgpK9hvw==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
+            "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
             "dev": true,
             "requires": {
-                "postcss": "^7.0.32",
-                "postcss-selector-parser": "^6.0.2"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    },
-                    "dependencies": {
-                        "supports-color": {
-                            "version": "5.5.0",
-                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                            "dev": true,
-                            "requires": {
-                                "has-flag": "^3.0.0"
-                            }
-                        }
-                    }
-                },
-                "color-convert": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-                    "dev": true
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
-                },
-                "postcss": {
-                    "version": "7.0.36",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.2",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^6.1.0"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
+                "postcss-selector-parser": "^6.0.6"
             }
         },
         "postcss-normalize-charset": {
@@ -18194,12 +17185,6 @@
             "dev": true,
             "optional": true
         },
-        "pretty-hrtime": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
-            "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE=",
-            "dev": true
-        },
         "pretty-time": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/pretty-time/-/pretty-time-1.1.0.tgz",
@@ -18314,6 +17299,12 @@
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
         },
+        "quick-lru": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+            "dev": true
+        },
         "randombytes": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -18393,24 +17384,6 @@
             "dev": true,
             "requires": {
                 "resolve": "^1.9.0"
-            }
-        },
-        "reduce-css-calc": {
-            "version": "2.1.8",
-            "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
-            "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
-            "dev": true,
-            "requires": {
-                "css-unit-converter": "^1.1.1",
-                "postcss-value-parser": "^3.3.0"
-            },
-            "dependencies": {
-                "postcss-value-parser": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
-                    "dev": true
-                }
             }
         },
         "regenerate": {
@@ -18517,13 +17490,14 @@
             "dev": true
         },
         "resolve": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+            "version": "1.22.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+            "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
             "dev": true,
             "requires": {
-                "is-core-module": "^2.2.0",
-                "path-parse": "^1.0.6"
+                "is-core-module": "^2.8.1",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
             }
         },
         "resolve-cwd": {
@@ -18964,23 +17938,6 @@
             "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
             "dev": true
         },
-        "simple-swizzle": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
-            "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-            "dev": true,
-            "requires": {
-                "is-arrayish": "^0.3.1"
-            },
-            "dependencies": {
-                "is-arrayish": {
-                    "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-                    "dev": true
-                }
-            }
-        },
         "slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -19370,6 +18327,12 @@
                 "has-flag": "^4.0.0"
             }
         },
+        "supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "dev": true
+        },
         "svgo": {
             "version": "2.8.0",
             "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.0.tgz",
@@ -19392,246 +18355,41 @@
             "dev": true
         },
         "tailwindcss": {
-            "version": "1.9.6",
-            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-1.9.6.tgz",
-            "integrity": "sha512-nY8WYM/RLPqGsPEGEV2z63riyQPcHYZUJpAwdyBzVpxQHOHqHE+F/fvbCeXhdF1+TA5l72vSkZrtYCB9hRcwkQ==",
+            "version": "3.0.24",
+            "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.0.24.tgz",
+            "integrity": "sha512-H3uMmZNWzG6aqmg9q07ZIRNIawoiEcNFKDfL+YzOPuPsXuDXxJxB9icqzLgdzKNwjG3SAro2h9SYav8ewXNgig==",
             "dev": true,
             "requires": {
-                "@fullhuman/postcss-purgecss": "^2.1.2",
-                "autoprefixer": "^9.4.5",
-                "browserslist": "^4.12.0",
-                "bytes": "^3.0.0",
-                "chalk": "^3.0.0 || ^4.0.0",
-                "color": "^3.1.2",
+                "arg": "^5.0.1",
+                "chokidar": "^3.5.3",
+                "color-name": "^1.1.4",
                 "detective": "^5.2.0",
-                "fs-extra": "^8.0.0",
-                "html-tags": "^3.1.0",
-                "lodash": "^4.17.20",
-                "node-emoji": "^1.8.1",
-                "normalize.css": "^8.0.1",
-                "object-hash": "^2.0.3",
-                "postcss": "^7.0.11",
-                "postcss-functions": "^3.0.0",
-                "postcss-js": "^2.0.0",
-                "postcss-nested": "^4.1.1",
-                "postcss-selector-parser": "^6.0.0",
-                "postcss-value-parser": "^4.1.0",
-                "pretty-hrtime": "^1.0.3",
-                "reduce-css-calc": "^2.1.6",
-                "resolve": "^1.14.2"
+                "didyoumean": "^1.2.2",
+                "dlv": "^1.1.3",
+                "fast-glob": "^3.2.11",
+                "glob-parent": "^6.0.2",
+                "is-glob": "^4.0.3",
+                "lilconfig": "^2.0.5",
+                "normalize-path": "^3.0.0",
+                "object-hash": "^3.0.0",
+                "picocolors": "^1.0.0",
+                "postcss": "^8.4.12",
+                "postcss-js": "^4.0.0",
+                "postcss-load-config": "^3.1.4",
+                "postcss-nested": "5.0.6",
+                "postcss-selector-parser": "^6.0.10",
+                "postcss-value-parser": "^4.2.0",
+                "quick-lru": "^5.1.1",
+                "resolve": "^1.22.0"
             },
             "dependencies": {
-                "@fullhuman/postcss-purgecss": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/@fullhuman/postcss-purgecss/-/postcss-purgecss-2.3.0.tgz",
-                    "integrity": "sha512-qnKm5dIOyPGJ70kPZ5jiz0I9foVOic0j+cOzNDoo8KoCf6HjicIZ99UfO2OmE7vCYSKAAepEwJtNzpiiZAh9xw==",
+                "glob-parent": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+                    "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
                     "dev": true,
                     "requires": {
-                        "postcss": "7.0.32",
-                        "purgecss": "^2.3.0"
-                    },
-                    "dependencies": {
-                        "chalk": {
-                            "version": "2.4.2",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                            "dev": true,
-                            "requires": {
-                                "ansi-styles": "^3.2.1",
-                                "escape-string-regexp": "^1.0.5",
-                                "supports-color": "^5.3.0"
-                            },
-                            "dependencies": {
-                                "supports-color": {
-                                    "version": "5.5.0",
-                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                                    "dev": true,
-                                    "requires": {
-                                        "has-flag": "^3.0.0"
-                                    }
-                                }
-                            }
-                        },
-                        "postcss": {
-                            "version": "7.0.32",
-                            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-                            "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-                            "dev": true,
-                            "requires": {
-                                "chalk": "^2.4.2",
-                                "source-map": "^0.6.1",
-                                "supports-color": "^6.1.0"
-                            }
-                        }
-                    }
-                },
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "autoprefixer": {
-                    "version": "9.8.6",
-                    "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.8.6.tgz",
-                    "integrity": "sha512-XrvP4VVHdRBCdX1S3WXVD8+RyG9qeb1D5Sn1DeLiG2xfSpzellk5k54xbUERJ3M5DggQxes39UGOTP8CFrEGbg==",
-                    "dev": true,
-                    "requires": {
-                        "browserslist": "^4.12.0",
-                        "caniuse-lite": "^1.0.30001109",
-                        "colorette": "^1.2.1",
-                        "normalize-range": "^0.1.2",
-                        "num2fraction": "^1.2.2",
-                        "postcss": "^7.0.32",
-                        "postcss-value-parser": "^4.1.0"
-                    }
-                },
-                "color-convert": {
-                    "version": "1.9.3",
-                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "dev": true,
-                    "requires": {
-                        "color-name": "1.1.3"
-                    }
-                },
-                "color-name": {
-                    "version": "1.1.3",
-                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-                    "dev": true
-                },
-                "commander": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-                    "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-                    "dev": true
-                },
-                "fs-extra": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-                    "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.2.0",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                },
-                "has-flag": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-                    "dev": true
-                },
-                "jsonfile": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-                    "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                },
-                "postcss": {
-                    "version": "7.0.36",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.36.tgz",
-                    "integrity": "sha512-BebJSIUMwJHRH0HAQoxN4u1CN86glsrwsW0q7T+/m44eXOUAxSNdHRkNZPYz5vVUbg17hFgOQDE7fZk7li3pZw==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.2",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^6.1.0"
-                    },
-                    "dependencies": {
-                        "chalk": {
-                            "version": "2.4.2",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                            "dev": true,
-                            "requires": {
-                                "ansi-styles": "^3.2.1",
-                                "escape-string-regexp": "^1.0.5",
-                                "supports-color": "^5.3.0"
-                            },
-                            "dependencies": {
-                                "supports-color": {
-                                    "version": "5.5.0",
-                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                                    "dev": true,
-                                    "requires": {
-                                        "has-flag": "^3.0.0"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "purgecss": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/purgecss/-/purgecss-2.3.0.tgz",
-                    "integrity": "sha512-BE5CROfVGsx2XIhxGuZAT7rTH9lLeQx/6M0P7DTXQH4IUc3BBzs9JUzt4yzGf3JrH9enkeq6YJBe9CTtkm1WmQ==",
-                    "dev": true,
-                    "requires": {
-                        "commander": "^5.0.0",
-                        "glob": "^7.0.0",
-                        "postcss": "7.0.32",
-                        "postcss-selector-parser": "^6.0.2"
-                    },
-                    "dependencies": {
-                        "chalk": {
-                            "version": "2.4.2",
-                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-                            "dev": true,
-                            "requires": {
-                                "ansi-styles": "^3.2.1",
-                                "escape-string-regexp": "^1.0.5",
-                                "supports-color": "^5.3.0"
-                            },
-                            "dependencies": {
-                                "supports-color": {
-                                    "version": "5.5.0",
-                                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                                    "dev": true,
-                                    "requires": {
-                                        "has-flag": "^3.0.0"
-                                    }
-                                }
-                            }
-                        },
-                        "postcss": {
-                            "version": "7.0.32",
-                            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-                            "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
-                            "dev": true,
-                            "requires": {
-                                "chalk": "^2.4.2",
-                                "source-map": "^0.6.1",
-                                "supports-color": "^6.1.0"
-                            }
-                        }
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "6.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
+                        "is-glob": "^4.0.3"
                     }
                 }
             }
@@ -19804,12 +18562,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
-            "dev": true
-        },
-        "traverse": {
-            "version": "0.6.6",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
-            "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
             "dev": true
         },
         "tslib": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "production": "cross-env NODE_ENV=production node_modules/webpack/bin/webpack.js --progress --config=node_modules/laravel-mix/setup/webpack.config.js"
     },
     "devDependencies": {
-        "@tailwindcss/custom-forms": "^0.2.1",
+        "@tailwindcss/forms": "^0.5.0",
+        "autoprefixer": "^10.4.4",
         "axios": ">=0.26.1",
         "bootstrap-sass": ">=3.4.1",
         "browser-sync": "^2.26.7",
@@ -19,11 +20,11 @@
         "laravel-mix": "^6.0.25",
         "laravel-mix-purgecss": "^6.0.0",
         "lodash": "^4.17.15",
-        "postcss": "^8.2.8",
+        "postcss": "^8.4.12",
         "resolve-url-loader": "^4.0.0",
         "sass": "^1.35.1",
         "sass-loader": "^12.1.0",
-        "tailwindcss": "^1.5.1",
+        "tailwindcss": "^3.0.24",
         "vue": "^2.6.7",
         "vue-loader": "^15.9.7",
         "vue-template-compiler": "^2.6.10"

--- a/resources/js/components/passport/Clients.vue
+++ b/resources/js/components/passport/Clients.vue
@@ -68,13 +68,13 @@
                 <input
                   id="name"
                   v-model="createForm.name"
-                  :class="{ 'border-red': createForm.errors.has('name') }"
+                  :class="{ 'border-red-500': createForm.errors.has('name') }"
                   class="block w-full h-full px-3 py-3 pr-3 text-gray-700 bg-gray-100 border rounded outline-none appearance-none focus:border-indigo-300 pl-9"
                   type="text"
                   placeholder="Something your users will recognize and trust."
                   @keyup.enter="store"
                 >
-                <has-error :form="createForm" class="text-red" field="name"/>
+                <has-error :form="createForm" class="text-red-500" field="name"/>
               </div>
               <div class="mb-6">
                 <label class="block mb-2 text-sm font-extrabold" for="redirecturl">Redirect Url</label>
@@ -87,7 +87,7 @@
                   placeholder="Your application's authorization callback URL."
                   @keyup.enter="store"
                 >
-                <has-error :form="createForm" class="text-red" field="redirect"/>
+                <has-error :form="createForm" class="text-red-500" field="redirect"/>
               </div>
               <div class="block flow-root">
                 <button

--- a/resources/js/components/passport/Clients.vue
+++ b/resources/js/components/passport/Clients.vue
@@ -89,7 +89,7 @@
                 >
                 <has-error :form="createForm" class="text-red" field="redirect"/>
               </div>
-              <div class="block clearfix">
+              <div class="block flow-root">
                 <button
                   class="float-right px-4 py-2 font-extrabold text-white bg-indigo-800 rounded hover:bg-indigo-500"
                   type="button"
@@ -147,7 +147,7 @@
                 >
                 <has-error :form="editForm" class="text-red-500" field="redirect"/>
               </div>
-              <div class="block clearfix">
+              <div class="block flow-root">
                 <button
                   class="float-right px-4 py-2 font-extrabold text-white bg-indigo-800 rounded hover:bg-indigo-500"
                   type="button"

--- a/resources/js/components/passport/PersonalAccessTokens.vue
+++ b/resources/js/components/passport/PersonalAccessTokens.vue
@@ -89,7 +89,7 @@
                   </div>
                 </div>
               </div>
-              <div class="block clearfix">
+              <div class="block flow-root">
                 <button
                   class="float-right px-4 py-2 font-extrabold text-white bg-indigo-800 rounded hover:bg-indigo-500"
                   type="button"

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -13,7 +13,7 @@
             Log in with <strong>GitHub</strong>
             @svg('github', 'inline-block align-top h-6 w-6')
         </a>
-        <p class="text-gray-400 text-base my-2">or</p>
+        <p class="text-base my-2">or</p>
     </div>
     @include('partials.log-in-form')
 </x-panel>

--- a/resources/views/components/input/radios.blade.php
+++ b/resources/views/components/input/radios.blade.php
@@ -24,6 +24,7 @@
                 type="radio"
                 name="{{ $name }}"
                 value="{{ $option }}"
+                class="bg-white border-form-200 form-radio"
                 @if ($option == old($name, $value)) checked @endif
             >
             <span class="ml-2 mr-6">{{ $label }}</span>

--- a/resources/views/components/input/text.blade.php
+++ b/resources/views/components/input/text.blade.php
@@ -22,7 +22,7 @@
         value="{{ old($name, $value) }}"
         {{ $attributes->except('class') }}
         class="
-            bg-white border-form-200 placeholder-form-400 rounded
+            bg-white border-form-200 form-input placeholder-form-400 rounded
             @unless ($inline) w-full @endunless
             @unless ($hideLabel) mt-1 @endunless
         "

--- a/resources/views/components/input/text.blade.php
+++ b/resources/views/components/input/text.blade.php
@@ -22,7 +22,7 @@
         value="{{ old($name, $value) }}"
         {{ $attributes->except('class') }}
         class="
-            form-input
+            bg-white border-form-200 placeholder-form-400 rounded
             @unless ($inline) w-full @endunless
             @unless ($hideLabel) mt-1 @endunless
         "

--- a/resources/views/components/input/textarea.blade.php
+++ b/resources/views/components/input/textarea.blade.php
@@ -22,7 +22,7 @@
         rows="{{ $rows }}"
         {{ $attributes->except('class') }}
         class="
-            form-textarea w-full
+            bg-white border-form-200 form-input placeholder-form-400 rounded w-full
             @unless ($hideLabel) mt-1 @endunless
         "
     >{{ old($name, $value) }}</textarea>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -96,7 +96,7 @@
 <div class="bg-indigo-800">
     <div class="flex flex-col max-w-md px-8 py-32 mx-auto sm:max-w-6xl">
         <h2 class="font-sans text-5xl text-center text-white">Conferences</h2>
-        <div class="flex flex-wrap justify-between mt-20 mb-16 lg:flex-no-wrap">
+        <div class="flex flex-wrap justify-between mt-20 mb-16 lg:flex-nowrap">
             @foreach ($conferences as $conference)
                 <div class="relative w-full px-8 pt-12 pb-24 mb-10 font-sans bg-white rounded-lg shadow lg:w-1/3 lg:first:mr-8 lg:last:ml-8 last:mb-0 lg:mb-0">
                     <div class="mb-12 text-2xl text-center text-indigo-800">{{ $conference->title }}</div>

--- a/resources/views/partials/nav.blade.php
+++ b/resources/views/partials/nav.blade.php
@@ -86,7 +86,7 @@
                 <a class="px-4 py-1 hover:bg-indigo-100 hover:text-indigo-500" href="{{ route('account.show') }}">Account</a>
                 @if (auth()->user()->enable_profile)
                     <a
-                        class="px-4 py-1 whitespace-no-wrap hover:bg-indigo-100 hover:text-indigo-500"
+                        class="px-4 py-1 whitespace-nowrap hover:bg-indigo-100 hover:text-indigo-500"
                         href="{{ route('speakers-public.show', auth()->user()->profile_slug) }}"
                     >
                         Public Speaker Profile

--- a/resources/views/partials/nav.blade.php
+++ b/resources/views/partials/nav.blade.php
@@ -62,7 +62,7 @@
 
     @if (auth()->guest())
         <div class="flex my-4 sm:ml-2 lg:mb-0 lg:mt-0 lg:block">
-            <a class="inline-block px-8 py-2 mt-4 text-indigo-800 transition duration-150 ease-in-out border rounded border-indigo hover:text-white hover:bg-indigo-800 md:ml-2 lg:ml-4 lg:block lg:ml-2 lg:mt-0 lg:px-4" href="#" v-on:click="slotProps.toggleSignInDropdown">
+            <a class="inline-block px-8 py-2 mt-4 text-indigo-800 transition duration-150 ease-in-out border rounded border-indigo hover:text-white hover:bg-indigo-800 md:ml-2 lg:ml-4 lg:block lg:mt-0 lg:px-4" href="#" v-on:click="slotProps.toggleSignInDropdown">
                 Sign in
             </a>
             <div class="absolute z-50 flex flex-col py-1 mt-0 ml-32 bg-white border rounded lg:mr-4 lg:w-1/3 lg:right-0 lg:mx-0 lg:mt-2 border-indigo xl:right-0" :class="slotProps.showSignInDropdown ? 'block' : 'hidden'">

--- a/resources/views/vendor/passport/authorize.blade.php
+++ b/resources/views/vendor/passport/authorize.blade.php
@@ -70,7 +70,7 @@
 
                                 <input type="hidden" name="state" value="{{ $request->state }}">
                                 <input type="hidden" name="client_id" value="{{ $client->id }}">
-                                <button type="submit" class="inline-block align-middle text-center select-none border font-normal whitespace-no-wrap py-2 px-4 rounded text-base leading-normal no-underline text-teal-lightest bg-teal-dark hover:bg-grey-darker btn-approve">Authorize</button>
+                                <button type="submit" class="inline-block align-middle text-center select-none border font-normal whitespace-nowrap py-2 px-4 rounded text-base leading-normal no-underline text-teal-lightest bg-teal-dark hover:bg-grey-darker btn-approve">Authorize</button>
                             </form>
 
                             <!-- Cancel Button -->
@@ -80,7 +80,7 @@
 
                                 <input type="hidden" name="state" value="{{ $request->state }}">
                                 <input type="hidden" name="client_id" value="{{ $client->id }}">
-                                <button class="inline-block align-middle text-center select-none border font-normal whitespace-no-wrap py-2 px-4 rounded text-base leading-normal no-underline text-white bg-red-dark hover:bg-grey-darker">Cancel</button>
+                                <button class="inline-block align-middle text-center select-none border font-normal whitespace-nowrap py-2 px-4 rounded text-base leading-normal no-underline text-white bg-red-dark hover:bg-grey-darker">Cancel</button>
                             </form>
                         </div>
                     </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,14 +1,48 @@
 const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
-    purge: [
-    './resources/**/*.blade.php',
-    './resources/**/*.js',
-    './resources/**/*.vue',
+    content: [
+        './resources/**/*.blade.php',
+        './resources/**/*.js',
+        './resources/**/*.vue',
     ],
     theme: {
+        colors: {
+            current: 'currentColor',
+            black: '#000',
+            white: '#fff',
+            indigo: {
+                DEFAULT: '#4b72D9',
+                100: '#F6F9FC',
+                150: '#EAF0FF',
+                300: '#a3bffa',
+                500: '#6A96FE',
+                800: '#4B72D9',
+                900: '#4C51BF',
+            },
+            gray: {
+                100: '#f7fafc',
+                200: '#edf2f7',
+                300: '#D8D8D8',
+                400: '#cbd5e0',
+                500: '#9B9B9B',
+                600: '#828080',
+                700: '#4a5568',
+            },
+            red: {
+                500: '#f56565',
+            },
+        },
         fontSize: {
-            ...defaultTheme.fontSize,
+            xs: '0.75rem',
+            sm: '0.875rem',
+            base: '1rem',
+            lg: '1.125rem',
+            xl: '1.25rem',
+            '2xl': '1.5rem',
+            '3xl': '1.875rem',
+            '4xl': '2.25rem',
+            '5xl': '3rem',
             '6xl': '4.3rem',
         },
         fontFamily: {
@@ -18,34 +52,13 @@ module.exports = {
             ],
         },
         extend: {
-            colors: {
-                indigo: {
-                    default: '#4b72D9',
-                    '100': '#F6F9FC',
-                    '150': '#EAF0FF',
-                    '500': '#6A96FE',
-                    '800': '#4B72D9',
-                    '900': '#4C51BF',
-                },
-                gray: {
-                    '300': '#D8D8D8',
-                    '500': '#9B9B9B',
-                    '600': '#828080',
-                },
-            },
             spacing: {
                 '0.5': '2px',
             },
         },
     },
-    variants: {
-        margin: ['responsive', 'first', 'last'],
-        borderWidth: ['responsive', 'first', 'last'],
-        inset: ['checked'],
-        borderColor: ['checked'],
-    },
     plugins: [
-        require('@tailwindcss/custom-forms'),
+        require('@tailwindcss/forms'),
         function ({ addComponents }) {
             const buttons = {
                 '.btn-github-login': {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -32,6 +32,10 @@ module.exports = {
             red: {
                 500: '#f56565',
             },
+            form: {
+                200: '#e2e8f0',
+                400: '#a0aec0',
+            },
         },
         fontSize: {
             xs: '0.75rem',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -62,7 +62,9 @@ module.exports = {
         },
     },
     plugins: [
-        require('@tailwindcss/forms'),
+        require('@tailwindcss/forms')({
+           strategy: 'class',
+        }),
         function ({ addComponents }) {
             const buttons = {
                 '.btn-github-login': {


### PR DESCRIPTION
This PR upgrades Tailwind to version 3 and replaces the `custom-forms` plugin with the new `forms` plugin. Classes have been updated to account for differences between Tailwind v1 and v3.