### PR TITLE
Update browser-sync for async security update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1871,9 +1871,9 @@
             }
         },
         "node_modules/@socket.io/component-emitter": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
-            "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+            "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
             "dev": true
         },
         "node_modules/@tailwindcss/forms": {
@@ -2813,15 +2813,18 @@
             }
         },
         "node_modules/async": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-            "dev": true
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+            "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+            "dev": true,
+            "dependencies": {
+                "lodash": "^4.17.14"
+            }
         },
         "node_modules/async-each-series": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
-            "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
+            "integrity": "sha512-p4jj6Fws4Iy2m0iCmI2am2ZNZCgbdgE+P8F/8csmn2vx7ixXrO2zGcuNsD46X5uZSVecmkEy/M06X2vG8KD6dQ==",
             "dev": true,
             "engines": {
                 "node": ">=0.8.0"
@@ -2948,12 +2951,6 @@
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
             }
-        },
-        "node_modules/backo2": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-            "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-            "dev": true
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
@@ -3112,13 +3109,13 @@
             "dev": true
         },
         "node_modules/browser-sync": {
-            "version": "2.27.9",
-            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.9.tgz",
-            "integrity": "sha512-3zBtggcaZIeU9so4ja9yxk7/CZu9B3DOL6zkxFpzHCHsQmkGBPVXg61jItbeoa+WXgNLnr1sYES/2yQwyEZ2+w==",
+            "version": "2.27.10",
+            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.10.tgz",
+            "integrity": "sha512-xKm+6KJmJu6RuMWWbFkKwOCSqQOxYe3nOrFkKI5Tr/ZzjPxyU3pFShKK3tWnazBo/3lYQzN7fzjixG8fwJh1Xw==",
             "dev": true,
             "dependencies": {
-                "browser-sync-client": "^2.27.9",
-                "browser-sync-ui": "^2.27.9",
+                "browser-sync-client": "^2.27.10",
+                "browser-sync-ui": "^2.27.10",
                 "bs-recipes": "1.3.4",
                 "bs-snippet-injector": "^2.0.1",
                 "chokidar": "^3.5.1",
@@ -3135,7 +3132,7 @@
                 "localtunnel": "^2.0.1",
                 "micromatch": "^4.0.2",
                 "opn": "5.3.0",
-                "portscanner": "2.1.1",
+                "portscanner": "2.2.0",
                 "qs": "6.2.3",
                 "raw-body": "^2.3.2",
                 "resp-modifier": "6.0.2",
@@ -3156,24 +3153,25 @@
             }
         },
         "node_modules/browser-sync-client": {
-            "version": "2.27.9",
-            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.9.tgz",
-            "integrity": "sha512-FHW8kydp7FXo6jnX3gXJCpHAHtWNLK0nx839nnK+boMfMI1n4KZd0+DmTxHBsHsF3OHud4V4jwoN8U5HExMIdQ==",
+            "version": "2.27.10",
+            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.10.tgz",
+            "integrity": "sha512-KCFKA1YDj6cNul0VsA28apohtBsdk5Wv8T82ClOZPZMZWxPj4Ny5AUbrj9UlAb/k6pdxE5HABrWDhP9+cjt4HQ==",
             "dev": true,
             "dependencies": {
                 "etag": "1.8.1",
                 "fresh": "0.5.2",
                 "mitt": "^1.1.3",
-                "rxjs": "^5.5.6"
+                "rxjs": "^5.5.6",
+                "typescript": "^4.6.2"
             },
             "engines": {
                 "node": ">=8.0.0"
             }
         },
         "node_modules/browser-sync-ui": {
-            "version": "2.27.9",
-            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.9.tgz",
-            "integrity": "sha512-rsduR2bRIwFvM8CX6iY/Nu5aWub0WB9zfSYg9Le/RV5N5DEyxJYey0VxdfWCnzDOoelassTDzYQo+r0iJno3qw==",
+            "version": "2.27.10",
+            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.10.tgz",
+            "integrity": "sha512-elbJILq4Uo6OQv6gsvS3Y9vRAJlWu+h8j0JDkF0X/ua+3S6SVbbiWnZc8sNOFlG7yvVGIwBED3eaYQ0iBo1Dtw==",
             "dev": true,
             "dependencies": {
                 "async-each-series": "0.1.1",
@@ -4647,20 +4645,16 @@
             }
         },
         "node_modules/engine.io-client": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.1.1.tgz",
-            "integrity": "sha512-V05mmDo4gjimYW+FGujoGmmmxRaDsrVr7AXA3ZIfa04MWM1jOfZfUwou0oNqhNwy/votUDvGDt4JA4QF4e0b4g==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.2.tgz",
+            "integrity": "sha512-8ZQmx0LQGRTYkHuogVZuGSpDqYZtCM/nv8zQ68VZ+JkOpazJ7ICdsSpaO6iXwvaU30oFg5QJOJWj8zWqhbKjkQ==",
             "dev": true,
             "dependencies": {
-                "@socket.io/component-emitter": "~3.0.0",
+                "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.1",
-                "engine.io-parser": "~5.0.0",
-                "has-cors": "1.1.0",
-                "parseqs": "0.0.6",
-                "parseuri": "0.0.6",
+                "engine.io-parser": "~5.0.3",
                 "ws": "~8.2.3",
-                "xmlhttprequest-ssl": "~2.0.0",
-                "yeast": "0.1.2"
+                "xmlhttprequest-ssl": "~2.0.0"
             }
         },
         "node_modules/engine.io-client/node_modules/debug": {
@@ -5510,12 +5504,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/has-cors": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-            "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
-            "dev": true
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
@@ -7421,18 +7409,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/parseqs": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-            "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
-            "dev": true
-        },
-        "node_modules/parseuri": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-            "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
-            "dev": true
-        },
         "node_modules/parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -7565,15 +7541,6 @@
                 "node": ">= 0.12.0"
             }
         },
-        "node_modules/portfinder/node_modules/async": {
-            "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-            "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-            "dev": true,
-            "dependencies": {
-                "lodash": "^4.17.14"
-            }
-        },
         "node_modules/portfinder/node_modules/debug": {
             "version": "3.2.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -7590,12 +7557,12 @@
             "dev": true
         },
         "node_modules/portscanner": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
-            "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
+            "integrity": "sha512-IFroCz/59Lqa2uBvzK3bKDbDDIEaAY8XJ1jFxcLWTqosrsc32//P4VuSB2vZXoHiHqOmx8B5L5hnKOxL/7FlPw==",
             "dev": true,
             "dependencies": {
-                "async": "1.5.2",
+                "async": "^2.6.0",
                 "is-number-like": "^1.0.3"
             },
             "engines": {
@@ -9273,17 +9240,15 @@
             "dev": true
         },
         "node_modules/socket.io-client": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.4.1.tgz",
-            "integrity": "sha512-N5C/L5fLNha5Ojd7Yeb/puKcPWWcoB/A09fEjjNsg91EDVr5twk/OEyO6VT9dlLSUNY85NpW6KBhVMvaLKQ3vQ==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.1.tgz",
+            "integrity": "sha512-e6nLVgiRYatS+AHXnOnGi4ocOpubvOUCGhyWw8v+/FxW8saHkinG6Dfhi9TU0Kt/8mwJIAASxvw6eujQmjdZVA==",
             "dev": true,
             "dependencies": {
-                "@socket.io/component-emitter": "~3.0.0",
-                "backo2": "~1.0.2",
+                "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.2",
-                "engine.io-client": "~6.1.1",
-                "parseuri": "0.0.6",
-                "socket.io-parser": "~4.1.1"
+                "engine.io-client": "~6.2.1",
+                "socket.io-parser": "~4.2.0"
             },
             "engines": {
                 "node": ">=10.0.0"
@@ -9313,12 +9278,12 @@
             "dev": true
         },
         "node_modules/socket.io-client/node_modules/socket.io-parser": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.2.tgz",
-            "integrity": "sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.0.tgz",
+            "integrity": "sha512-tLfmEwcEwnlQTxFB7jibL/q2+q8dlVQzj4JdRLJ/W/G1+Fu9VSxCx1Lo+n1HvXxKnM//dUuD0xgiA7tQf57Vng==",
             "dev": true,
             "dependencies": {
-                "@socket.io/component-emitter": "~3.0.0",
+                "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.1"
             },
             "engines": {
@@ -10109,6 +10074,19 @@
             },
             "engines": {
                 "node": ">= 0.6"
+            }
+        },
+        "node_modules/typescript": {
+            "version": "4.6.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+            "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+            "dev": true,
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=4.2.0"
             }
         },
         "node_modules/ua-parser-js": {
@@ -10952,12 +10930,6 @@
             "engines": {
                 "node": ">=12"
             }
-        },
-        "node_modules/yeast": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-            "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
-            "dev": true
         }
     },
     "dependencies": {
@@ -12270,9 +12242,9 @@
             "dev": true
         },
         "@socket.io/component-emitter": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.0.0.tgz",
-            "integrity": "sha512-2pTGuibAXJswAPJjaKisthqS/NOK5ypG4LYT6tEAV0S/mxW0zOIvYvGK0V8w8+SHxAm6vRMSjqSalFXeBAqs+Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
+            "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg==",
             "dev": true
         },
         "@tailwindcss/forms": {
@@ -13114,15 +13086,18 @@
             }
         },
         "async": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-            "dev": true
+            "version": "2.6.4",
+            "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+            "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.14"
+            }
         },
         "async-each-series": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-0.1.1.tgz",
-            "integrity": "sha1-dhfBkXQB/Yykooqtzj266Yr+tDI=",
+            "integrity": "sha512-p4jj6Fws4Iy2m0iCmI2am2ZNZCgbdgE+P8F/8csmn2vx7ixXrO2zGcuNsD46X5uZSVecmkEy/M06X2vG8KD6dQ==",
             "dev": true
         },
         "autoprefixer": {
@@ -13210,12 +13185,6 @@
             "requires": {
                 "@babel/helper-define-polyfill-provider": "^0.3.1"
             }
-        },
-        "backo2": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
-            "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
-            "dev": true
         },
         "balanced-match": {
             "version": "1.0.2",
@@ -13341,13 +13310,13 @@
             "dev": true
         },
         "browser-sync": {
-            "version": "2.27.9",
-            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.9.tgz",
-            "integrity": "sha512-3zBtggcaZIeU9so4ja9yxk7/CZu9B3DOL6zkxFpzHCHsQmkGBPVXg61jItbeoa+WXgNLnr1sYES/2yQwyEZ2+w==",
+            "version": "2.27.10",
+            "resolved": "https://registry.npmjs.org/browser-sync/-/browser-sync-2.27.10.tgz",
+            "integrity": "sha512-xKm+6KJmJu6RuMWWbFkKwOCSqQOxYe3nOrFkKI5Tr/ZzjPxyU3pFShKK3tWnazBo/3lYQzN7fzjixG8fwJh1Xw==",
             "dev": true,
             "requires": {
-                "browser-sync-client": "^2.27.9",
-                "browser-sync-ui": "^2.27.9",
+                "browser-sync-client": "^2.27.10",
+                "browser-sync-ui": "^2.27.10",
                 "bs-recipes": "1.3.4",
                 "bs-snippet-injector": "^2.0.1",
                 "chokidar": "^3.5.1",
@@ -13364,7 +13333,7 @@
                 "localtunnel": "^2.0.1",
                 "micromatch": "^4.0.2",
                 "opn": "5.3.0",
-                "portscanner": "2.1.1",
+                "portscanner": "2.2.0",
                 "qs": "6.2.3",
                 "raw-body": "^2.3.2",
                 "resp-modifier": "6.0.2",
@@ -13379,21 +13348,22 @@
             }
         },
         "browser-sync-client": {
-            "version": "2.27.9",
-            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.9.tgz",
-            "integrity": "sha512-FHW8kydp7FXo6jnX3gXJCpHAHtWNLK0nx839nnK+boMfMI1n4KZd0+DmTxHBsHsF3OHud4V4jwoN8U5HExMIdQ==",
+            "version": "2.27.10",
+            "resolved": "https://registry.npmjs.org/browser-sync-client/-/browser-sync-client-2.27.10.tgz",
+            "integrity": "sha512-KCFKA1YDj6cNul0VsA28apohtBsdk5Wv8T82ClOZPZMZWxPj4Ny5AUbrj9UlAb/k6pdxE5HABrWDhP9+cjt4HQ==",
             "dev": true,
             "requires": {
                 "etag": "1.8.1",
                 "fresh": "0.5.2",
                 "mitt": "^1.1.3",
-                "rxjs": "^5.5.6"
+                "rxjs": "^5.5.6",
+                "typescript": "^4.6.2"
             }
         },
         "browser-sync-ui": {
-            "version": "2.27.9",
-            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.9.tgz",
-            "integrity": "sha512-rsduR2bRIwFvM8CX6iY/Nu5aWub0WB9zfSYg9Le/RV5N5DEyxJYey0VxdfWCnzDOoelassTDzYQo+r0iJno3qw==",
+            "version": "2.27.10",
+            "resolved": "https://registry.npmjs.org/browser-sync-ui/-/browser-sync-ui-2.27.10.tgz",
+            "integrity": "sha512-elbJILq4Uo6OQv6gsvS3Y9vRAJlWu+h8j0JDkF0X/ua+3S6SVbbiWnZc8sNOFlG7yvVGIwBED3eaYQ0iBo1Dtw==",
             "dev": true,
             "requires": {
                 "async-each-series": "0.1.1",
@@ -14565,20 +14535,16 @@
             }
         },
         "engine.io-client": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.1.1.tgz",
-            "integrity": "sha512-V05mmDo4gjimYW+FGujoGmmmxRaDsrVr7AXA3ZIfa04MWM1jOfZfUwou0oNqhNwy/votUDvGDt4JA4QF4e0b4g==",
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.2.2.tgz",
+            "integrity": "sha512-8ZQmx0LQGRTYkHuogVZuGSpDqYZtCM/nv8zQ68VZ+JkOpazJ7ICdsSpaO6iXwvaU30oFg5QJOJWj8zWqhbKjkQ==",
             "dev": true,
             "requires": {
-                "@socket.io/component-emitter": "~3.0.0",
+                "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.1",
-                "engine.io-parser": "~5.0.0",
-                "has-cors": "1.1.0",
-                "parseqs": "0.0.6",
-                "parseuri": "0.0.6",
+                "engine.io-parser": "~5.0.3",
                 "ws": "~8.2.3",
-                "xmlhttprequest-ssl": "~2.0.0",
-                "yeast": "0.1.2"
+                "xmlhttprequest-ssl": "~2.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -15195,12 +15161,6 @@
                     "dev": true
                 }
             }
-        },
-        "has-cors": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
-            "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
-            "dev": true
         },
         "has-flag": {
             "version": "4.0.0",
@@ -16645,18 +16605,6 @@
                 "lines-and-columns": "^1.1.6"
             }
         },
-        "parseqs": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
-            "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w==",
-            "dev": true
-        },
-        "parseuri": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
-            "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow==",
-            "dev": true
-        },
         "parseurl": {
             "version": "1.3.3",
             "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -16759,15 +16707,6 @@
                 "mkdirp": "^0.5.5"
             },
             "dependencies": {
-                "async": {
-                    "version": "2.6.3",
-                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-                    "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-                    "dev": true,
-                    "requires": {
-                        "lodash": "^4.17.14"
-                    }
-                },
                 "debug": {
                     "version": "3.2.7",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -16786,12 +16725,12 @@
             }
         },
         "portscanner": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.1.1.tgz",
-            "integrity": "sha1-6rtAnk3iSVD1oqUW01rnaTQ/u5Y=",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-2.2.0.tgz",
+            "integrity": "sha512-IFroCz/59Lqa2uBvzK3bKDbDDIEaAY8XJ1jFxcLWTqosrsc32//P4VuSB2vZXoHiHqOmx8B5L5hnKOxL/7FlPw==",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
+                "async": "^2.6.0",
                 "is-number-like": "^1.0.3"
             }
         },
@@ -17982,17 +17921,15 @@
             "dev": true
         },
         "socket.io-client": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.4.1.tgz",
-            "integrity": "sha512-N5C/L5fLNha5Ojd7Yeb/puKcPWWcoB/A09fEjjNsg91EDVr5twk/OEyO6VT9dlLSUNY85NpW6KBhVMvaLKQ3vQ==",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.5.1.tgz",
+            "integrity": "sha512-e6nLVgiRYatS+AHXnOnGi4ocOpubvOUCGhyWw8v+/FxW8saHkinG6Dfhi9TU0Kt/8mwJIAASxvw6eujQmjdZVA==",
             "dev": true,
             "requires": {
-                "@socket.io/component-emitter": "~3.0.0",
-                "backo2": "~1.0.2",
+                "@socket.io/component-emitter": "~3.1.0",
                 "debug": "~4.3.2",
-                "engine.io-client": "~6.1.1",
-                "parseuri": "0.0.6",
-                "socket.io-parser": "~4.1.1"
+                "engine.io-client": "~6.2.1",
+                "socket.io-parser": "~4.2.0"
             },
             "dependencies": {
                 "debug": {
@@ -18011,12 +17948,12 @@
                     "dev": true
                 },
                 "socket.io-parser": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.1.2.tgz",
-                    "integrity": "sha512-j3kk71QLJuyQ/hh5F/L2t1goqzdTL0gvDzuhTuNSwihfuFUrcSji0qFZmJJPtG6Rmug153eOPsUizeirf1IIog==",
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.0.tgz",
+                    "integrity": "sha512-tLfmEwcEwnlQTxFB7jibL/q2+q8dlVQzj4JdRLJ/W/G1+Fu9VSxCx1Lo+n1HvXxKnM//dUuD0xgiA7tQf57Vng==",
                     "dev": true,
                     "requires": {
-                        "@socket.io/component-emitter": "~3.0.0",
+                        "@socket.io/component-emitter": "~3.1.0",
                         "debug": "~4.3.1"
                     }
                 }
@@ -18590,6 +18527,12 @@
                 "media-typer": "0.3.0",
                 "mime-types": "~2.1.24"
             }
+        },
+        "typescript": {
+            "version": "4.6.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+            "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
+            "dev": true
         },
         "ua-parser-js": {
             "version": "1.0.2",
@@ -19195,12 +19138,6 @@
             "version": "21.0.1",
             "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
             "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
-            "dev": true
-        },
-        "yeast": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
-            "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
             "dev": true
         }
     }


### PR DESCRIPTION
This PR updates browser-sync to `v2.27.10`, which updates async to `v2.6.4`.