### PR TITLE
Globally ignore archived talks

### DIFF
--- a/app/Collections/TalksCollection.php
+++ b/app/Collections/TalksCollection.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Collections;
+
+use App\Models\Talk;
+use Illuminate\Database\Eloquent\Collection;
+
+class TalksCollection extends Collection
+{
+    public function sortByTitle()
+    {
+        return $this->sortBy(function (Talk $talk) {
+            return strtolower($talk->current()->title);
+        })->values();
+    }
+}

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -131,7 +131,7 @@ class AccountController extends BaseController
         $tempName = sprintf('%d_export.json', $user->id);
         $exportName = sprintf('export_%s.json', date('Y_m_d'));
 
-        $export = ['talks' => $user->talks->toArray()];
+        $export = ['talks' => $user->talks->sortByTitle()->toArray()];
 
         $storage
             ->disk('local')

--- a/app/Http/Controllers/Api/UserTalksController.php
+++ b/app/Http/Controllers/Api/UserTalksController.php
@@ -18,12 +18,20 @@ class UserTalksController extends BaseController
             App::abort(404);
         }
 
-        $return = auth()->guard('api')->user()->talks->map(function ($talk) {
-            return new Talk($talk);
-        })->values();
+        $talks = auth()->guard('api')
+            ->user()
+            ->talks()
+            ->when((boolean) request()->query('include-archived'), function ($query) {
+                $query->withoutGlobalScope('active');
+            })
+            ->get()
+            ->sortByTitle()
+            ->map(function ($talk) {
+                return new Talk($talk);
+            })->values();
 
         return response()->jsonApi([
-            'data' => $return,
+            'data' => $talks,
         ]);
     }
 }

--- a/app/Http/Controllers/Api/UserTalksController.php
+++ b/app/Http/Controllers/Api/UserTalksController.php
@@ -18,7 +18,7 @@ class UserTalksController extends BaseController
             App::abort(404);
         }
 
-        $return = auth()->guard('api')->user()->activeTalks->map(function ($talk) {
+        $return = auth()->guard('api')->user()->talks->map(function ($talk) {
             return new Talk($talk);
         })->values();
 

--- a/app/Http/Controllers/ConferencesController.php
+++ b/app/Http/Controllers/ConferencesController.php
@@ -89,7 +89,7 @@ class ConferencesController extends BaseController
             return redirect('/');
         }
 
-        $talks = auth()->user()->talks->map(function ($talk) use ($conference) {
+        $talks = auth()->user()->talks->sortByTitle()->map(function ($talk) use ($conference) {
             return TalkTransformer::transform($talk, $conference);
         });
 

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -8,9 +8,7 @@ class DashboardController extends Controller
 {
     public function index()
     {
-        $talks = auth()->user()->talks->sortBy(function (Talk $talk) {
-            return strtolower($talk->current()->title);
-        });
+        $talks = auth()->user()->talks->sortByTitle();
 
         $submissionsByConference = $talks->filter(function (Talk $talk) {
             return $talk->submissions()->exists();

--- a/app/Http/Controllers/PublicProfileController.php
+++ b/app/Http/Controllers/PublicProfileController.php
@@ -45,11 +45,7 @@ class PublicProfileController extends Controller
     public function show($profile_slug)
     {
         $user = $this->getPublicUserByProfileSlug($profile_slug);
-
-        $talks = $user->talks()->public()->get()->sortBy(function ($talk) {
-            return $talk->current()->title;
-        });
-
+        $talks = $user->talks()->public()->get()->sortByTitle();
         $bios = $user->bios()->public()->get();
 
         return view('account.public-profile.show', [

--- a/app/Http/Controllers/TalksController.php
+++ b/app/Http/Controllers/TalksController.php
@@ -199,7 +199,7 @@ class TalksController extends BaseController
                 return auth()->user()->talks()->accepted()->get();
                 break;
             default:
-                return auth()->user()->talks()->active()->get();
+                return auth()->user()->talks()->get();
                 break;
         }
     }

--- a/app/Http/Controllers/TalksController.php
+++ b/app/Http/Controllers/TalksController.php
@@ -161,7 +161,7 @@ class TalksController extends BaseController
     public function archiveIndex(Request $request)
     {
         $talks = $this->sortTalks(
-            auth()->user()->talks()->archived()->get(),
+            auth()->user()->archivedTalks()->get(),
             $request->input('sort')
         );
 

--- a/app/Models/Talk.php
+++ b/app/Models/Talk.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Collections\TalksCollection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
@@ -36,6 +37,11 @@ class Talk extends UuidBase
         static::addGlobalScope('active', function (Builder $builder) {
             $builder->where('is_archived', false);
         });
+    }
+
+    public function newCollection(array $models = [])
+    {
+        return new TalksCollection($models);
     }
 
     public function author()

--- a/app/Models/Talk.php
+++ b/app/Models/Talk.php
@@ -95,11 +95,6 @@ class Talk extends UuidBase
         return $query->where('is_archived', true);
     }
 
-    public function scopeActive($query)
-    {
-        return $query->where('is_archived', false);
-    }
-
     public function scopeSubmitted($query)
     {
         $query->has('submissions');

--- a/app/Models/Talk.php
+++ b/app/Models/Talk.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 class Talk extends UuidBase
@@ -27,6 +28,13 @@ class Talk extends UuidBase
 
         static::deleting(function (self $talk) {
             $talk->revisions()->delete();
+        });
+    }
+
+    protected static function booted()
+    {
+        static::addGlobalScope('active', function (Builder $builder) {
+            $builder->where('is_archived', false);
         });
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -66,11 +66,6 @@ class User extends Authenticatable
         return $this->hasMany(Talk::class, 'author_id');
     }
 
-    public function activeTalks()
-    {
-        return $this->hasMany(Talk::class, 'author_id');
-    }
-
     public function archivedTalks()
     {
         return $this->hasMany(Talk::class, 'author_id')
@@ -87,7 +82,7 @@ class User extends Authenticatable
 
     public function getActiveTalksAttribute()
     {
-        return $this->activeTalks()->get()->sortBy(function ($talk) {
+        return $this->talks()->get()->sortBy(function ($talk) {
             return strtolower($talk->current()->title);
         })->values();
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -73,13 +73,6 @@ class User extends Authenticatable
             ->archived();
     }
 
-    public function getActiveTalksAttribute()
-    {
-        return $this->talks()->get()->sortBy(function ($talk) {
-            return strtolower($talk->current()->title);
-        })->values();
-    }
-
     public function bios()
     {
         return $this->hasMany(Bio::class)->orderBy('nickname');

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -73,13 +73,6 @@ class User extends Authenticatable
             ->archived();
     }
 
-    public function getTalksAttribute()
-    {
-        return $this->talks()->get()->sortBy(function ($talk) {
-            return strtolower($talk->current()->title);
-        })->values();
-    }
-
     public function getActiveTalksAttribute()
     {
         return $this->talks()->get()->sortBy(function ($talk) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -68,7 +68,7 @@ class User extends Authenticatable
 
     public function activeTalks()
     {
-        return $this->hasMany(Talk::class, 'author_id')->where('is_archived', false);
+        return $this->hasMany(Talk::class, 'author_id');
     }
 
     public function getTalksAttribute()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -71,6 +71,13 @@ class User extends Authenticatable
         return $this->hasMany(Talk::class, 'author_id');
     }
 
+    public function archivedTalks()
+    {
+        return $this->hasMany(Talk::class, 'author_id')
+            ->withoutGlobalScope('active')
+            ->archived();
+    }
+
     public function getTalksAttribute()
     {
         return $this->talks()->get()->sortBy(function ($talk) {

--- a/database/factories/TalkFactory.php
+++ b/database/factories/TalkFactory.php
@@ -2,8 +2,11 @@
 
 namespace Database\Factories;
 
+use App\Models\Talk;
+use App\Models\TalkRevision;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
 
 class TalkFactory extends Factory
 {
@@ -14,9 +17,9 @@ class TalkFactory extends Factory
         ];
     }
 
-    public function author($author)
+    public function author(User $user)
     {
-        return $this->for($author, 'author');
+        return $this->for($user, 'author');
     }
 
     public function archived()
@@ -24,5 +27,20 @@ class TalkFactory extends Factory
         return $this->state([
             'is_archived' => true,
         ]);
+    }
+
+    public function revised(array $revisions)
+    {
+        return $this->afterCreating(function (Talk $talk) use ($revisions) {
+            $this->revise(
+                $talk,
+                array_merge(['created_at' => Carbon::now()], $revisions),
+            );
+        });
+    }
+
+    private function revise(Talk $talk, $attributes = [])
+    {
+        TalkRevision::factory()->for($talk)->create($attributes);
     }
 }

--- a/database/factories/TalkFactory.php
+++ b/database/factories/TalkFactory.php
@@ -18,4 +18,11 @@ class TalkFactory extends Factory
     {
         return $this->for($author, 'author');
     }
+
+    public function archived()
+    {
+        return $this->state([
+            'is_archived' => true,
+        ]);
+    }
 }

--- a/resources/views/talks/index.blade.php
+++ b/resources/views/talks/index.blade.php
@@ -1,7 +1,5 @@
 @extends('layouts.index', ['title' => 'My Talks'])
 
-@section('content')
-
 @section('sidebar')
     <x-side-menu
         title="Filter"

--- a/tests/Api/TalkApiTest.php
+++ b/tests/Api/TalkApiTest.php
@@ -37,6 +37,34 @@ class TalkApiTest extends ApiTestCase
     }
 
     /** @test */
+    public function including_archived_talks()
+    {
+        Talk::factory()
+            ->author($this->user)
+            ->archived()
+            ->revised(['title' => 'My Archived Talk'])
+            ->create();
+
+        $response = $this->json('GET', 'api/user/1/talks?include-archived=1');
+
+        $response->assertJsonFragment(['title' => 'My Archived Talk']);
+    }
+
+    /** @test */
+    public function excluding_archived_talks()
+    {
+        Talk::factory()
+            ->author($this->user)
+            ->archived()
+            ->revised(['title' => 'My Archived Talk'])
+            ->create();
+
+        $response = $this->json('GET', 'api/user/1/talks?include-archived=0');
+
+        $response->assertJsonMissing(['title' => 'My Archived Talk']);
+    }
+
+    /** @test */
     public function all_talks_return_alpha_sorted()
     {
         $response = $this->call('GET', 'api/user/1/talks');

--- a/tests/Feature/TalkTest.php
+++ b/tests/Feature/TalkTest.php
@@ -36,6 +36,28 @@ class TalkTest extends TestCase
     }
 
     /** @test */
+    function active_talks_are_not_included_on_the_archived_index_page()
+    {
+        $user = User::factory()->create();
+        Talk::factory()
+            ->author($user)
+            ->revised(['title' => 'my active talk'])
+            ->create();
+        Talk::factory()
+            ->author($user)
+            ->revised(['title' => 'my archived talk'])
+            ->archived()
+            ->create();
+
+        $response = $this->actingAs($user)
+            ->get('archive')
+            ->assertSuccessful();
+
+        $response->assertSee('my archived talk');
+        $response->assertDontSee('my active talk');
+    }
+
+    /** @test */
     public function it_shows_the_talk_title_on_its_page()
     {
         $user = User::factory()->create();

--- a/tests/Feature/TalkTest.php
+++ b/tests/Feature/TalkTest.php
@@ -79,8 +79,8 @@ class TalkTest extends TestCase
         $talk1 = Talk::factory()->author($user)->revised(['title' => 'zyxwv'])->create();
         $talk2 = Talk::factory()->author($user)->revised(['title' => 'abcde'])->create();
 
-        $this->assertEquals('abcde', $user->talks->first()->current()->title);
-        $this->assertEquals('zyxwv', $user->talks->last()->current()->title);
+        $this->assertEquals('abcde', $user->talks->sortByTitle()->first()->current()->title);
+        $this->assertEquals('zyxwv', $user->talks->sortByTitle()->last()->current()->title);
     }
 
     /** @test */

--- a/tests/Feature/TalkTest.php
+++ b/tests/Feature/TalkTest.php
@@ -182,4 +182,17 @@ class TalkTest extends TestCase
         $this->assertContains($talkRevisionA->talk_id, $acceptedTalkIds);
         $this->assertNotContains($talkRevisionB->talk_id, $acceptedTalkIds);
     }
+
+    /** @test */
+    function archived_talks_are_not_included_in_queries_by_default()
+    {
+        $talk = Talk::factory()->archived()->create();
+
+        $activeTalks = Talk::all();
+        $this->assertNotContains($talk->id, $activeTalks->pluck('id'));
+
+        // talk is included when excluding query scope
+        $allTalks = Talk::withoutGlobalScope('active')->get();
+        $this->assertContains($talk->id, $allTalks->pluck('id'));
+    }
 }

--- a/tests/Feature/TalkTest.php
+++ b/tests/Feature/TalkTest.php
@@ -14,6 +14,28 @@ use Tests\TestCase;
 class TalkTest extends TestCase
 {
     /** @test */
+    function archived_talks_are_not_included_on_the_index_page()
+    {
+        $user = User::factory()->create();
+        Talk::factory()
+            ->author($user)
+            ->revised(['title' => 'my active talk'])
+            ->create();
+        Talk::factory()
+            ->author($user)
+            ->revised(['title' => 'my archived talk'])
+            ->archived()
+            ->create();
+
+        $response = $this->actingAs($user)
+            ->get('talks')
+            ->assertSuccessful();
+
+        $response->assertSee('my active talk');
+        $response->assertDontSee('my archived talk');
+    }
+
+    /** @test */
     public function it_shows_the_talk_title_on_its_page()
     {
         $user = User::factory()->create();

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Models\Talk;
 use App\Models\User;
 use Tests\TestCase;
 
@@ -26,5 +27,18 @@ class UserTest extends TestCase
         User::factory()->wantsNotifications()->create();
 
         $this->assertEquals(1, User::wantsNotifications()->count());
+    }
+
+    /** @test */
+    function archived_talks_are_not_included_in_active_talks_relationship()
+    {
+        $user = User::factory()->create();
+        $activeTalk = Talk::factory()->author($user)->create();
+        $archivedTalk = Talk::factory()->author($user)->archived()->create();
+
+        $activeTalks = $user->activeTalks()->get();
+
+        $this->assertContains($activeTalk->id, $activeTalks->pluck('id'));
+        $this->assertNotContains($archivedTalk->id, $activeTalks->pluck('id'));
     }
 }

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -30,13 +30,13 @@ class UserTest extends TestCase
     }
 
     /** @test */
-    function archived_talks_are_not_included_in_active_talks_relationship()
+    function archived_talks_are_not_included_in_the_talks_relationship()
     {
         $user = User::factory()->create();
         $activeTalk = Talk::factory()->author($user)->create();
         $archivedTalk = Talk::factory()->author($user)->archived()->create();
 
-        $activeTalks = $user->activeTalks()->get();
+        $activeTalks = $user->talks()->get();
 
         $this->assertContains($activeTalk->id, $activeTalks->pluck('id'));
         $this->assertNotContains($archivedTalk->id, $activeTalks->pluck('id'));


### PR DESCRIPTION
This PR closes #201 by adding an `active` global scope on the `Talk` model.  As a result of this change, the `User::activeTalks` relationship has been removed since it is equivalent to `User::talks`.

The `user/{userId}/talks` API endpoint now supports including archived talks by adding `include-archived=1` in the query string.  This change includes replacing the `User::getTalksAttributes` and `User::getActiveTalksAttribute` method with a `sortByTitle` on a custom `TalksCollection`.