### PR TITLE
Update Tighten footer link

### DIFF
--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -7,7 +7,7 @@
         <footer>
             <div class="flex flex-col justify-between px-8 text-center lg:flex-row xl:px-0 lg:text-left">
                 <div class="hover:underline">
-                    <a href="http://tighten.co/" target="_blank">&copy; Tighten Co. {{ date('Y') }}</a>
+                    <a href="http://tighten.com/" target="_blank">&copy; Tighten {{ date('Y') }}</a>
                 </div>
                 <div class="invisible lg:visible">|</div>
                 <div class="hover:underline">


### PR DESCRIPTION
This PR makes the following updates to the Tighten link in the footer:
- `tighten.co` changed to `tighten.com`
- `Tighten Co.` changed to `Tighten`

<img width="289" alt="image" src="https://user-images.githubusercontent.com/1121383/179843132-a7b3c7af-f293-450d-b4cf-ea9aae52409d.png">
