### PR TITLE
Improve conference description display

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -23,6 +23,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        Blade::withoutDoubleEncoding();
+
         Blade::directive('sorted', function ($expression) {
             list($sorted_by, $query) = explode(',', $expression, 2);
 

--- a/resources/views/conferences/listing.blade.php
+++ b/resources/views/conferences/listing.blade.php
@@ -39,7 +39,7 @@
         @endif
     </x-slot>
     <x-slot name="body">
-        {{ mb_substr($conference->description, 0, 100) }}...
+        {{ str($conference->description)->limit(100) }}...
     </x-slot>
     <x-slot name="footer">
         <div class="pr-3 lg:pr-0">

--- a/resources/views/conferences/show.blade.php
+++ b/resources/views/conferences/show.blade.php
@@ -54,8 +54,7 @@
         @endif
 
         <div class="mt-4 text-gray-500">Description:</div>
-        <!-- TODO: Figure out how we will be handling HTML/etc. -->
-        {!! str_replace("\n", "<br>", $conference->description) !!}</p>
+        <p>{{ $conference->description }}</p>
     </div>
 
     <x-slot name="footer">

--- a/resources/views/conferences/showPublic.blade.php
+++ b/resources/views/conferences/showPublic.blade.php
@@ -13,7 +13,7 @@
         <a href="{{ $conference->url }}">{{ $conference->url }}</a>
 
         <div class="mt-4 text-gray-500">Description:</div>
-        {!! str_replace("\n", "<br>", $conference->description) !!}</p>
+        <p>{{ $conference->description }}</p>
     </div>
     <x-slot name="footer">
         <div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -101,7 +101,7 @@
                 <div class="relative w-full px-8 pt-12 pb-24 mb-10 font-sans bg-white rounded-lg shadow lg:w-1/3 lg:first:mr-8 lg:last:ml-8 last:mb-0 lg:mb-0">
                     <div class="mb-12 text-2xl text-center text-indigo-800">{{ $conference->title }}</div>
                     <div class="text-xl font-medium">{{ $conference->event_dates_display }}</div>
-                    <div class="mt-6 text-xl">{{ mb_substr($conference->description, 0, 100) }}</div>
+                    <div class="mt-6 text-xl">{{ str($conference->description)->limit(100) }}</div>
                     <div class="absolute bottom-0 block my-10">
                         <a
                             class="text-xl font-semibold text-indigo-800"

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -101,7 +101,7 @@
                 <div class="relative w-full px-8 pt-12 pb-24 mb-10 font-sans bg-white rounded-lg shadow lg:w-1/3 lg:first:mr-8 lg:last:ml-8 last:mb-0 lg:mb-0">
                     <div class="mb-12 text-2xl text-center text-indigo-800">{{ $conference->title }}</div>
                     <div class="text-xl font-medium">{{ $conference->event_dates_display }}</div>
-                    <div class="mt-6 text-xl">{{ $conference->description }}</div>
+                    <div class="mt-6 text-xl">{{ mb_substr($conference->description, 0, 100) }}</div>
                     <div class="absolute bottom-0 block my-10">
                         <a
                             class="text-xl font-semibold text-indigo-800"


### PR DESCRIPTION
This PR improves the display of conference descriptions by removing Blade double encoding.  Additionally, featured conference descriptions are now truncated on the home page.

| Page | Before | After |
| - | - | - |
| Home page featured conferences | <img width="351" alt="image" src="https://user-images.githubusercontent.com/1121383/180285698-98af10b1-2df4-4a5e-9657-354e894d4dde.png"> | <img width="357" alt="image" src="https://user-images.githubusercontent.com/1121383/180284638-0676ef6e-7186-4a31-a202-fe92e7e3bdd7.png"> |
| Conference page listing | <img width="611" alt="image" src="https://user-images.githubusercontent.com/1121383/180285983-7117b3cf-fca0-46ff-af7f-7c952dc6ed4d.png"> | <img width="613" alt="image" src="https://user-images.githubusercontent.com/1121383/180285308-9558a6a4-8c9a-4ba0-ba80-f9def4848742.png"> |
| Conference show page | <img width="787" alt="image" src="https://user-images.githubusercontent.com/1121383/180286161-202f25b4-650d-481d-b896-464d7aed5343.png"> | <img width="781" alt="image" src="https://user-images.githubusercontent.com/1121383/180285531-5f7673ae-b49c-47be-b8d7-25d66cfb75cd.png"> |