### PR TITLE
Speaker search improvements

### DIFF
--- a/app/Http/Controllers/PublicProfileController.php
+++ b/app/Http/Controllers/PublicProfileController.php
@@ -15,8 +15,7 @@ class PublicProfileController extends Controller
 {
     public function index(SpeakerSearchRequest $request)
     {
-        $users = User::search($request->get('query'))
-            ->query(fn ($query) => $query->whereHasPublicProfile())
+        $users = User::searchPublicSpeakers($request->query('query'))
             ->orderBy('name', 'asc')
             ->get();
 

--- a/app/Http/Controllers/PublicProfileController.php
+++ b/app/Http/Controllers/PublicProfileController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\SpeakerSearchRequest;
 use App\Mail\ContactRequest;
 use App\Models\User;
 use Captcha\Captcha;
@@ -24,7 +25,7 @@ class PublicProfileController extends Controller
         ]);
     }
 
-    public function search(Request $request)
+    public function search(SpeakerSearchRequest $request)
     {
         $users = User::search($request->get('query'))
             ->orderBy('name', 'asc')->get();

--- a/app/Http/Controllers/PublicProfileController.php
+++ b/app/Http/Controllers/PublicProfileController.php
@@ -21,7 +21,7 @@ class PublicProfileController extends Controller
 
         return view('account.public-profile.index', [
             'speakers' => $users,
-            'query' => $request->query('query'),
+            'query' => $request->original,
         ]);
     }
 

--- a/app/Http/Controllers/PublicProfileController.php
+++ b/app/Http/Controllers/PublicProfileController.php
@@ -13,33 +13,16 @@ use Illuminate\Support\Facades\Session;
 
 class PublicProfileController extends Controller
 {
-    public function index()
+    public function index(SpeakerSearchRequest $request)
     {
-        $users = User::where('enable_profile', true)
-            ->whereNotNull('profile_slug')
+        $users = User::search($request->get('query'))
+            ->query(fn ($query) => $query->whereHasPublicProfile())
             ->orderBy('name', 'asc')
             ->get();
 
         return view('account.public-profile.index', [
             'speakers' => $users,
-        ]);
-    }
-
-    public function search(SpeakerSearchRequest $request)
-    {
-        $users = User::search($request->get('query'))
-            ->orderBy('name', 'asc')->get();
-
-        // Since Scout searches can only perform rudimentary where clauses,
-        // we must filter search results to only validly public profiles.
-        $filteredUsers = $users->filter(function ($user) {
-            return $user->enable_profile == true &&
-                ! is_null($user->profile_slug);
-        });
-
-        return view('account.public-profile.index', [
-            'speakers' => $filteredUsers,
-            'query' => $request->get('query'),
+            'query' => $request->query('query'),
         ]);
     }
 

--- a/app/Http/Requests/SpeakerSearchRequest.php
+++ b/app/Http/Requests/SpeakerSearchRequest.php
@@ -22,7 +22,10 @@ class SpeakerSearchRequest extends FormRequest
     public function prepareForValidation()
     {
         optional(State::abbreviation($this->query('query')), function ($value) {
-            $this->merge(['query' => $value]);
+            $this->merge([
+                'query' => $value,
+                'original' => $this->query('query'),
+            ]);
         });
     }
 }

--- a/app/Http/Requests/SpeakerSearchRequest.php
+++ b/app/Http/Requests/SpeakerSearchRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Models\State;
+use Illuminate\Foundation\Http\FormRequest;
+
+class SpeakerSearchRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            //
+        ];
+    }
+
+    public function prepareForValidation()
+    {
+        optional(State::abbreviation($this->input('query')), function ($value) {
+            $this->merge(['query' => $value]);
+        });
+    }
+}

--- a/app/Http/Requests/SpeakerSearchRequest.php
+++ b/app/Http/Requests/SpeakerSearchRequest.php
@@ -21,7 +21,7 @@ class SpeakerSearchRequest extends FormRequest
 
     public function prepareForValidation()
     {
-        optional(State::abbreviation($this->input('query')), function ($value) {
+        optional(State::abbreviation($this->query('query')), function ($value) {
             $this->merge(['query' => $value]);
         });
     }

--- a/app/Models/State.php
+++ b/app/Models/State.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Models;
+
+class State
+{
+    const INDEX = [
+        'AL' => 'ALABAMA',
+        'AK' => 'ALASKA',
+        'AS' => 'AMERICAN SAMOA',
+        'AZ' => 'ARIZONA',
+        'AR' => 'ARKANSAS',
+        'CA' => 'CALIFORNIA',
+        'CO' => 'COLORADO',
+        'CT' => 'CONNECTICUT',
+        'DE' => 'DELAWARE',
+        'DC' => 'DISTRICT OF COLUMBIA',
+        'FM' => 'FEDERATED STATES OF MICRONESIA',
+        'FL' => 'FLORIDA',
+        'GA' => 'GEORGIA',
+        'GU' => 'GUAM GU',
+        'HI' => 'HAWAII',
+        'ID' => 'IDAHO',
+        'IL' => 'ILLINOIS',
+        'IN' => 'INDIANA',
+        'IA' => 'IOWA',
+        'KS' => 'KANSAS',
+        'KY' => 'KENTUCKY',
+        'LA' => 'LOUISIANA',
+        'ME' => 'MAINE',
+        'MH' => 'MARSHALL ISLANDS',
+        'MD' => 'MARYLAND',
+        'MA' => 'MASSACHUSETTS',
+        'MI' => 'MICHIGAN',
+        'MN' => 'MINNESOTA',
+        'MS' => 'MISSISSIPPI',
+        'MO' => 'MISSOURI',
+        'MT' => 'MONTANA',
+        'NE' => 'NEBRASKA',
+        'NV' => 'NEVADA',
+        'NH' => 'NEW HAMPSHIRE',
+        'NJ' => 'NEW JERSEY',
+        'NM' => 'NEW MEXICO',
+        'NY' => 'NEW YORK',
+        'NC' => 'NORTH CAROLINA',
+        'ND' => 'NORTH DAKOTA',
+        'MP' => 'NORTHERN MARIANA ISLANDS',
+        'OH' => 'OHIO',
+        'OK' => 'OKLAHOMA',
+        'OR' => 'OREGON',
+        'PW' => 'PALAU',
+        'PA' => 'PENNSYLVANIA',
+        'PR' => 'PUERTO RICO',
+        'RI' => 'RHODE ISLAND',
+        'SC' => 'SOUTH CAROLINA',
+        'SD' => 'SOUTH DAKOTA',
+        'TN' => 'TENNESSEE',
+        'TX' => 'TEXAS',
+        'UT' => 'UTAH',
+        'VT' => 'VERMONT',
+        'VI' => 'VIRGIN ISLANDS',
+        'VA' => 'VIRGINIA',
+        'WA' => 'WASHINGTON',
+        'WV' => 'WEST VIRGINIA',
+        'WI' => 'WISCONSIN',
+        'WY' => 'WYOMING',
+        'AB' => 'ALBERTA',
+        'BC' => 'BRITISH COLUMBIA',
+        'MB' => 'MANITOBA',
+        'NB' => 'NEW BRUNSWICK',
+        'NL' => 'NEWFOUNDLAND',
+        'NT' => 'NORTHWEST TERRITORIES',
+        'NS' => 'NOVA SCOTIA',
+        'NU' => 'NUNAVUT',
+        'ON' => 'ONTARIO',
+        'PE' => 'PRINCE EDWARD ISLAND',
+        'QC' => 'QUEBEC',
+        'SK' => 'SASKATCHEWAN',
+        'YT' => 'YUKON',
+    ];
+
+    public static function abbreviation($value)
+    {
+        // if the value is an abbreviation return the abbreviation
+        if (array_key_exists(strtoupper($value), static::INDEX)) {
+            return strtoupper($value);
+        }
+
+        // search the index for the abbreviation by value
+        return array_search(strtoupper($value), static::INDEX) ?: null;
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -46,6 +46,16 @@ class User extends Authenticatable
         });
     }
 
+    public static function searchPublicSpeakers($query)
+    {
+        if (! $query) {
+            return static::whereHasPublicProfile();
+        }
+
+        return static::search($query)
+            ->query(fn ($query) => $query->whereHasPublicProfile());
+    }
+
     public function scopeWhereHasPublicProfile($query)
     {
         $query->where('enable_profile', true)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -46,6 +46,12 @@ class User extends Authenticatable
         });
     }
 
+    public function scopeWhereHasPublicProfile($query)
+    {
+        $query->where('enable_profile', true)
+            ->whereNotNull('profile_slug');
+    }
+
     public function scopeWantsNotifications($query)
     {
         return $query->where('wants_notifications', true);

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -35,7 +35,7 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
-        <env name="SCOUT_DRIVER" value="null"/>
+        <env name="SCOUT_DRIVER" value="database"/>
         <env name="CAPTCHA_PUBLIC" value="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"/>
         <env name="CAPTCHA_PRIVATE" value="6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"/>
     </php>

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -53,6 +53,11 @@ Vue.component(
     require('./components/ModalToggle.vue').default
 );
 
+Vue.component(
+    'UpdateQueryString',
+    require('./components/UpdateQueryString.vue').default
+);
+
 new Vue({
     el: "#app",
 });

--- a/resources/js/components/UpdateQueryString.vue
+++ b/resources/js/components/UpdateQueryString.vue
@@ -13,12 +13,20 @@
             return this.$scopedSlots.default({
                 queryValue: this.queryValue,
                 updateQueryString: this.updateQueryString,
+                clearQueryString: this.clearQueryString,
             });
         },
 
         methods: {
             updateQueryString(name, value) {
                 this.url.searchParams.set(name, value);
+                this.updateUrl();
+            },
+            clearQueryString(name) {
+                this.url.searchParams.delete(name);
+                this.updateUrl();
+            },
+            updateUrl() {
                 window.location.href = this.url.toString();
             },
         },

--- a/resources/js/components/UpdateQueryString.vue
+++ b/resources/js/components/UpdateQueryString.vue
@@ -1,0 +1,26 @@
+<script>
+    export default {
+        name: 'updateQueryString',
+
+        data() {
+            return {
+                url: new URL(window.location.href),
+                queryValue: '',
+            };
+        },
+
+        render() {
+            return this.$scopedSlots.default({
+                queryValue: this.queryValue,
+                updateQueryString: this.updateQueryString,
+            });
+        },
+
+        methods: {
+            updateQueryString(name, value) {
+                this.url.searchParams.set(name, value);
+                window.location.href = this.url.toString();
+            },
+        },
+    }
+</script>

--- a/resources/views/account/public-profile/index.blade.php
+++ b/resources/views/account/public-profile/index.blade.php
@@ -10,7 +10,7 @@
             <x-input.text
                 name="query"
                 label="Query"
-                placeholder="Search"
+                placeholder="Name or Location"
                 :hideLabel="true"
                 :inline="true"
                 v-model="queryValue"

--- a/resources/views/account/public-profile/index.blade.php
+++ b/resources/views/account/public-profile/index.blade.php
@@ -14,6 +14,7 @@
                 :hideLabel="true"
                 :inline="true"
                 v-model="queryValue"
+                @keyup.enter="updateQueryString('query', queryValue)"
             ></x-input.text>
             <x-button.primary class="ml-2" @click="updateQueryString('query', queryValue)">
                 Search

--- a/resources/views/account/public-profile/index.blade.php
+++ b/resources/views/account/public-profile/index.blade.php
@@ -5,8 +5,8 @@
 <x-panel>
     <p class="mb-4">These are all the speakers who have a public profile on Symposium.</p>
 
-    <x-form :action="route('speakers-public.search')">
-        <div class="flex">
+    <update-query-string>
+        <div slot-scope="{ updateQueryString, queryValue }" class="flex">
             <x-input.text
                 name="query"
                 label="Query"
@@ -14,10 +14,13 @@
                 :hideLabel="true"
                 :inline="true"
                 class="mr-2"
+                v-model="queryValue"
             ></x-input.text>
-            <x-button.primary type="submit">Search</x-button.primary>
+            <x-button.primary type="submit" @click="updateQueryString('query', queryValue)">
+                Search
+            </x-button.primary>
         </div>
-    </x-form>
+    </update-query-string>
 
     <p class="mb-8 text-gray-500">
         @if (isset($query) && $query)

--- a/resources/views/account/public-profile/index.blade.php
+++ b/resources/views/account/public-profile/index.blade.php
@@ -6,19 +6,19 @@
     <p class="mb-4">These are all the speakers who have a public profile on Symposium.</p>
 
     <update-query-string>
-        <div slot-scope="{ updateQueryString, queryValue }" class="flex">
+        <div slot-scope="{ updateQueryString, clearQueryString, queryValue }" class="flex">
             <x-input.text
                 name="query"
                 label="Query"
                 placeholder="Search"
                 :hideLabel="true"
                 :inline="true"
-                class="mr-2"
                 v-model="queryValue"
             ></x-input.text>
-            <x-button.primary type="submit" @click="updateQueryString('query', queryValue)">
+            <x-button.primary class="ml-2" @click="updateQueryString('query', queryValue)">
                 Search
             </x-button.primary>
+            <x-button.secondary class="ml-2" @click="clearQueryString('query')">Reset</x-button.secondary>
         </div>
     </update-query-string>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,7 +27,6 @@ Route::get('what-is-this', function () {
 });
 
 Route::get('speakers', [PublicProfileController::class, 'index'])->name('speakers-public.index');
-Route::post('speakers', [PublicProfileController::class, 'search'])->name('speakers-public.search');
 Route::get('u/{profileSlug}', [PublicProfileController::class, 'show'])->name('speakers-public.show');
 Route::get('u/{profileSlug}/talks/{talkId}', [PublicProfileController::class, 'showTalk'])->name('speakers-public.talks.show');
 Route::get('u/{profileSlug}/bios/{bioId}', [PublicProfileController::class, 'showBio'])->name('speakers-public.bios.show');

--- a/tests/Feature/PublicSpeakerProfileTest.php
+++ b/tests/Feature/PublicSpeakerProfileTest.php
@@ -35,6 +35,86 @@ class PublicSpeakerProfileTest extends TestCase
     }
 
     /** @test */
+    function speakers_can_be_found_by_searching_state_abbreviation()
+    {
+        User::factory()->enableProfile()->create([
+            'name' => 'Caleb Dume',
+            'state' => 'MA',
+        ]);
+        User::factory()->enableProfile()->create([
+            'name' => 'Ezra Bridger',
+            'state' => 'NY',
+        ]);
+
+        $response = $this->post(route('speakers-public.search'), [
+            'query' => 'MA',
+        ])->assertSuccessful();
+
+        $response->assertSee('Caleb Dume');
+        $response->assertDontSee('Ezra Bridger');
+    }
+
+    /** @test */
+    function searching_by_state_abbreviation_is_case_insensitive()
+    {
+        User::factory()->enableProfile()->create([
+            'name' => 'Caleb Dume',
+            'state' => 'MA',
+        ]);
+        User::factory()->enableProfile()->create([
+            'name' => 'Ezra Bridger',
+            'state' => 'NY',
+        ]);
+
+        $response = $this->post(route('speakers-public.search'), [
+            'query' => 'ma',
+        ])->assertSuccessful();
+
+        $response->assertSee('Caleb Dume');
+        $response->assertDontSee('Ezra Bridger');
+    }
+
+    /** @test */
+    function speakers_can_be_found_by_searching_state_name()
+    {
+        User::factory()->enableProfile()->create([
+            'name' => 'Caleb Dume',
+            'state' => 'MA',
+        ]);
+        User::factory()->enableProfile()->create([
+            'name' => 'Ezra Bridger',
+            'state' => 'NY',
+        ]);
+
+        $response = $this->post(route('speakers-public.search'), [
+            'query' => 'Massachusetts',
+        ])->assertSuccessful();
+
+        $response->assertSee('Caleb Dume');
+        $response->assertDontSee('Ezra Bridger');
+    }
+
+    /** @test */
+    function searching_by_state_name_is_case_insensitive()
+    {
+        User::factory()->enableProfile()->create([
+            'name' => 'Caleb Dume',
+            'state' => 'SC',
+        ]);
+        User::factory()->enableProfile()->create([
+            'name' => 'Ezra Bridger',
+            'state' => 'NY',
+        ]);
+
+        $response = $this->post(route('speakers-public.search'), [
+            'query' => 'souTh caroLina',
+        ])->assertSuccessful();
+
+        $response->assertSee('Caleb Dume');
+        $response->assertDontSee('Ezra Bridger');
+    }
+
+    /** @test */
     public function non_public_speakers_do_not_have_public_speaker_profile_pages()
     {
         $user = User::factory()->disableProfile()->create([

--- a/tests/Feature/PublicSpeakerProfileTest.php
+++ b/tests/Feature/PublicSpeakerProfileTest.php
@@ -46,9 +46,9 @@ class PublicSpeakerProfileTest extends TestCase
             'state' => 'NY',
         ]);
 
-        $response = $this->post(route('speakers-public.search'), [
+        $response = $this->get(route('speakers-public.index', [
             'query' => 'MA',
-        ])->assertSuccessful();
+        ]))->assertSuccessful();
 
         $response->assertSee('Caleb Dume');
         $response->assertDontSee('Ezra Bridger');
@@ -66,9 +66,9 @@ class PublicSpeakerProfileTest extends TestCase
             'state' => 'NY',
         ]);
 
-        $response = $this->post(route('speakers-public.search'), [
+        $response = $this->get(route('speakers-public.index', [
             'query' => 'ma',
-        ])->assertSuccessful();
+        ]))->assertSuccessful();
 
         $response->assertSee('Caleb Dume');
         $response->assertDontSee('Ezra Bridger');
@@ -86,9 +86,9 @@ class PublicSpeakerProfileTest extends TestCase
             'state' => 'NY',
         ]);
 
-        $response = $this->post(route('speakers-public.search'), [
+        $response = $this->get(route('speakers-public.index', [
             'query' => 'Massachusetts',
-        ])->assertSuccessful();
+        ]))->assertSuccessful();
 
         $response->assertSee('Caleb Dume');
         $response->assertDontSee('Ezra Bridger');
@@ -106,9 +106,9 @@ class PublicSpeakerProfileTest extends TestCase
             'state' => 'NY',
         ]);
 
-        $response = $this->post(route('speakers-public.search'), [
+        $response = $this->get(route('speakers-public.index', [
             'query' => 'souTh caroLina',
-        ])->assertSuccessful();
+        ]))->assertSuccessful();
 
         $response->assertSee('Caleb Dume');
         $response->assertDontSee('Ezra Bridger');


### PR DESCRIPTION
This PR closes #224 by making the following improvements to the speaker search page:
- Speakers can be searched by state name in addition to abbreviation
    - This is implemented by mapping the state name to the abbreviation without needing to update the search index
- A `Reset` button has been added to reset the search results
- The search placeholder text has been updated to read `Name or Location`
- The speaker search page has been combined to a single `speakers.index` route
    - The `Search` button now refreshes the current page with the search term appended in the query string
    - The `speakers.search` route has been removed

**Querying by state name**
<img width="653" alt="image" src="https://user-images.githubusercontent.com/1121383/181298875-843a8d3e-0ee6-484c-802f-3c31207498af.png">
