### PR TITLE
Hide dismissed conferences on calendar

### DIFF
--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -12,9 +12,9 @@ class CalendarController extends BaseController
     {
         return view('calendar', [
             'events' => CalendarEventCollection::make([])
-                ->addConferences(Conference::approved()->whereAfter(Carbon::now()->subYear())->whereHasDates()->get())
-                ->addCfpOpenings(Conference::approved()->whereAfter(Carbon::now()->subYear())->whereHasCfpStart()->get())
-                ->addCfpClosings(Conference::approved()->whereAfter(Carbon::now()->subYear())->whereHasCfpEnd()->get())
+                ->addConferences(Conference::approved()->undismissed()->whereAfter(Carbon::now()->subYear())->whereHasDates()->get())
+                ->addCfpOpenings(Conference::approved()->undismissed()->whereAfter(Carbon::now()->subYear())->whereHasCfpStart()->get())
+                ->addCfpClosings(Conference::approved()->undismissed()->whereAfter(Carbon::now()->subYear())->whereHasCfpEnd()->get())
                 ->toJson(),
         ]);
     }

--- a/app/Http/Controllers/CalendarController.php
+++ b/app/Http/Controllers/CalendarController.php
@@ -12,10 +12,18 @@ class CalendarController extends BaseController
     {
         return view('calendar', [
             'events' => CalendarEventCollection::make([])
-                ->addConferences(Conference::approved()->undismissed()->whereAfter(Carbon::now()->subYear())->whereHasDates()->get())
-                ->addCfpOpenings(Conference::approved()->undismissed()->whereAfter(Carbon::now()->subYear())->whereHasCfpStart()->get())
-                ->addCfpClosings(Conference::approved()->undismissed()->whereAfter(Carbon::now()->subYear())->whereHasCfpEnd()->get())
+                ->addConferences($this->query()->whereHasDates()->get())
+                ->addCfpOpenings($this->query()->whereHasCfpStart()->get())
+                ->addCfpClosings($this->query()->whereHasCfpEnd()->get())
                 ->toJson(),
         ]);
+    }
+
+    private function query()
+    {
+        return Conference::query()
+            ->approved()
+            ->undismissed()
+            ->whereAfter(Carbon::now()->subYear());
     }
 }

--- a/database/factories/ConferenceFactory.php
+++ b/database/factories/ConferenceFactory.php
@@ -83,4 +83,11 @@ class ConferenceFactory extends Factory
                 ->create();
         });
     }
+
+    public function dismissedBy(User $user)
+    {
+        return $this->afterCreating(function (Conference $conference) use ($user) {
+            $user->dismissedConferences()->attach($conference->id);
+        });
+    }
 }

--- a/tests/Feature/CalendarTest.php
+++ b/tests/Feature/CalendarTest.php
@@ -26,4 +26,23 @@ class CalendarTest extends TestCase
             ->assertSee('Approved conference')
             ->assertDontSee('Unapproved conference');
     }
+
+    /** @test */
+    function user_dismissed_conferences_do_not_appear_on_the_calendar()
+    {
+        $user = User::factory()->create();
+
+        Conference::factory()->approved()->dismissedBy($user)->create([
+            'title' => 'Dismissed conference',
+        ]);
+
+        Conference::factory()->approved()->create([
+            'title' => 'Approved conference',
+        ]);
+
+        $this->actingAs($user)->get('calendar')
+            ->assertSuccessful()
+            ->assertSee('Approved conference')
+            ->assertDontSee('Dismissed conference');
+    }
 }


### PR DESCRIPTION
This PR updates the calendar page to hide conferences that have been dismissed by the authenticated user.