### PR TITLE
Improve tag & description display

### DIFF
--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -373,7 +373,7 @@ class Conference extends UuidBase
 
     public function getFormattedDescriptionAttribute()
     {
-        $description = str_replace("&#13;", "<br />", $this->description);
+        $description = str_replace('&#13;', '<br />', $this->description);
 
         return linkify($description);
     }

--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -371,6 +371,13 @@ class Conference extends UuidBase
         });
     }
 
+    public function getFormattedDescriptionAttribute()
+    {
+        $description = str_replace("&#13;", "<br />", $this->description);
+
+        return linkify($description);
+    }
+
     public function reportIssue($reason, $note, User $user)
     {
         $issue = $this->issues()->create([

--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -373,7 +373,12 @@ class Conference extends UuidBase
 
     public function getFormattedDescriptionAttribute()
     {
-        $description = str_replace('&#13;', '<br />', $this->description);
+        $description = htmlspecialchars($this->description, ENT_IGNORE, 'UTF-8');
+
+        $description = str_replace('&amp;amp;', '&', $description);
+        $description = str_replace('&amp;#39;', "'", $description);
+        $description = str_replace('&amp;#34;', '"', $description);
+        $description = str_replace('&amp;#13;', '<br />', $description);
 
         return linkify($description);
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -10,7 +10,7 @@ if (! function_exists('markdown')) {
 if (! function_exists('linkify')) {
     function linkify($text)
     {
-        if (!$text) {
+        if (! $text) {
             return '';
         }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -6,3 +6,16 @@ if (! function_exists('markdown')) {
         return '<div class="markdown">' . (new Parsedown())->text($text) . '</div>';
     }
 }
+
+if (! function_exists('linkify')) {
+    function linkify($text)
+    {
+        if (!$text) {
+            return '';
+        }
+
+        $pattern = '@(https?://([-\w\.]+[-\w])+(:\d+)?(/([\w/_\.#-]*(\?\S+)?[^\.\s\)\<])?)?)@';
+
+        return preg_replace($pattern, '<a href="$0" target="_blank" rel="noopener noreferrer" class="text-gray-500 hover:text-indigo-500">$0</a>', $text);
+    }
+}

--- a/resources/views/components/panel/conference.blade.php
+++ b/resources/views/components/panel/conference.blade.php
@@ -48,7 +48,7 @@
         @endif
 
         <div class="mt-4 text-gray-500">Description:</div>
-        <p>{{ $conference->description }}</p>
+        <p>{!! $conference->formatted_description !!}</p>
 
         @if ($conference->speaker_package->count())
             <div class="mt-4 text-gray-500">Speaker Package:</div>

--- a/resources/views/components/tag.blade.php
+++ b/resources/views/components/tag.blade.php
@@ -1,5 +1,5 @@
 <span
-    class="px-1 ml-4 text-xs font-semibold text-white bg-indigo-500 rounded"
+    class="px-1 ml-4 text-xs font-semibold text-white bg-indigo-500 rounded whitespace-nowrap"
 >
     {{ $slot }}
 </span>


### PR DESCRIPTION
**What's changed:**
- Conference page: now text wrap in tag
- Conference detail:
  - make url linkable
  - convert new line to link break

**Screenshots:**

from:
<img width="557" alt="Screen Shot 2565-10-01 at 19 37 26" src="https://user-images.githubusercontent.com/1849256/193410297-7bd17c88-ea4e-42fb-8809-3cd2d2f188ea.png">

to:
<img width="557" alt="Screen Shot 2565-10-01 at 19 36 07" src="https://user-images.githubusercontent.com/1849256/193410298-180cb245-89e6-4119-a199-39d2702c6239.png">

from:
<img width="675" alt="Screen Shot 2565-10-01 at 19 37 15" src="https://user-images.githubusercontent.com/1849256/193410340-84c6f004-b255-4837-b51f-ae17a7171c8a.png">

to:
<img width="666" alt="Screen Shot 2565-10-01 at 19 48 39" src="https://user-images.githubusercontent.com/1849256/193410368-5b328d55-28fc-458f-9d4a-a2fea4996a4a.png">


