### PR TITLE
Improve conference importer visibility

### DIFF
--- a/app/CallingAllPapers/Client.php
+++ b/app/CallingAllPapers/Client.php
@@ -12,10 +12,7 @@ class Client
 
     public function __construct(GuzzleClient $client = null)
     {
-        $this->guzzle = $client ?: new GuzzleClient([
-            'headers'  => ['User-Agent' => 'Symposium CLI'],
-            'base_uri' => 'https://api.callingallpapers.com/v1/cfp',
-        ]);
+        $this->guzzle = $client;
     }
 
     public function getEvents()

--- a/app/CallingAllPapers/Client.php
+++ b/app/CallingAllPapers/Client.php
@@ -2,9 +2,9 @@
 
 namespace App\CallingAllPapers;
 
+use App\CallingAllPapers\Event;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\json_decode;
-use Illuminate\Support\Facades\Event;
 
 class Client
 {

--- a/app/CallingAllPapers/Client.php
+++ b/app/CallingAllPapers/Client.php
@@ -10,7 +10,7 @@ class Client
 {
     private $guzzle;
 
-    public function __construct(GuzzleClient $client = null)
+    public function __construct(GuzzleClient $client)
     {
         $this->guzzle = $client;
     }

--- a/app/CallingAllPapers/ConferenceImporter.php
+++ b/app/CallingAllPapers/ConferenceImporter.php
@@ -10,15 +10,12 @@ use Illuminate\Support\Facades\Validator;
 
 class ConferenceImporter
 {
-    private $client;
-
     private $authorId;
 
     private $geocoder;
 
-    public function __construct(int $authorId = null, Client $client = null)
+    public function __construct(int $authorId = null)
     {
-        $this->client = $client ?: new Client();
         $this->authorId = $authorId ?: auth()->user()->id;
         $this->geocoder = app(Geocoder::class);
     }

--- a/app/CallingAllPapers/ConferenceImporter.php
+++ b/app/CallingAllPapers/ConferenceImporter.php
@@ -62,15 +62,18 @@ class ConferenceImporter
             ],
         ]);
 
-        if ($validator->fails()) {
-            return response($validator->errors(), 403);
-        }
-
         $conference = Conference::firstOrNew(['calling_all_papers_id' => $event->id]);
         $this->updateConferenceFromCallingAllPapersEvent($conference, $event);
 
         if (! $conference->latitude && ! $conference->longitude && $conference->location) {
             $this->geocodeLatLongFromLocation($conference);
+        }
+
+        if ($validator->fails()) {
+            $conference->rejected_at = now();
+            $conference->save();
+
+            return;
         }
 
         $conference->save();

--- a/app/CallingAllPapers/ConferenceImporter.php
+++ b/app/CallingAllPapers/ConferenceImporter.php
@@ -71,12 +71,11 @@ class ConferenceImporter
 
         if ($validator->fails()) {
             $conference->rejected_at = now();
-            $conference->save();
-
-            return;
         }
 
         $conference->save();
+
+        return $conference;
     }
 
     private function updateConferenceFromCallingAllPapersEvent(Conference $conference, Event $event)

--- a/app/Console/Commands/SyncCallingAllPapersEvents.php
+++ b/app/Console/Commands/SyncCallingAllPapersEvents.php
@@ -16,18 +16,18 @@ class SyncCallingAllPapersEvents extends Command
 
     protected $description = 'Pull down CallingAllPapers events';
 
-    protected $slack;
-
     protected $client;
+
+    protected $slack;
 
     private $importer;
 
-    public function __construct(TightenSlack $slack)
+    public function __construct(Client $client, TightenSlack $slack)
     {
         parent::__construct();
 
+        $this->client = $client;
         $this->slack = $slack;
-        $this->client = new Client();
         $this->importer = new ConferenceImporter($adminUserId = 1);
     }
 

--- a/app/Console/Commands/SyncCallingAllPapersEvents.php
+++ b/app/Console/Commands/SyncCallingAllPapersEvents.php
@@ -4,6 +4,8 @@ namespace App\Console\Commands;
 
 use App\CallingAllPapers\Client;
 use App\CallingAllPapers\ConferenceImporter;
+use App\Models\TightenSlack;
+use App\Notifications\ConferenceImporterStarted;
 use Exception;
 use Illuminate\Console\Command;
 
@@ -28,6 +30,7 @@ class SyncCallingAllPapersEvents extends Command
     public function handle()
     {
         $this->info('Syncing events...');
+        (new TightenSlack())->notify(new ConferenceImporterStarted());
 
         try {
             $events = $this->client->getEvents();

--- a/app/Console/Commands/SyncCallingAllPapersEvents.php
+++ b/app/Console/Commands/SyncCallingAllPapersEvents.php
@@ -7,6 +7,7 @@ use App\CallingAllPapers\ConferenceImporter;
 use App\Models\TightenSlack;
 use App\Notifications\ConferenceImporterError;
 use App\Notifications\ConferenceImporterFinished;
+use App\Notifications\ConferenceImporterRejection;
 use App\Notifications\ConferenceImporterStarted;
 use Exception;
 use Illuminate\Console\Command;
@@ -48,7 +49,11 @@ class SyncCallingAllPapersEvents extends Command
 
         foreach ($events as $event) {
             $this->info("Creating/updating event {$event->name}");
-            $this->importer->import($event);
+            $conference = $this->importer->import($event);
+
+            if ($conference->rejected_at) {
+                $this->slack->notify(new ConferenceImporterRejection($conference));
+            }
         }
 
         $this->info('Events synced.');

--- a/app/Console/Commands/SyncCallingAllPapersEvents.php
+++ b/app/Console/Commands/SyncCallingAllPapersEvents.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\CallingAllPapers\Client;
 use App\CallingAllPapers\ConferenceImporter;
 use App\Models\TightenSlack;
+use App\Notifications\ConferenceImporterError;
 use App\Notifications\ConferenceImporterFinished;
 use App\Notifications\ConferenceImporterStarted;
 use Exception;
@@ -40,6 +41,7 @@ class SyncCallingAllPapersEvents extends Command
             $events = $this->client->getEvents();
         } catch (Exception $exception) {
             $this->error("Unable to sync Calling All Papers events. Message: {$exception->getMessage()}");
+            $this->slack->notify(new ConferenceImporterError($exception));
 
             return;
         }

--- a/app/Http/Controllers/ConferencesController.php
+++ b/app/Http/Controllers/ConferencesController.php
@@ -90,7 +90,11 @@ class ConferencesController extends Controller
         }
 
         try {
-            $conference = Conference::findOrFail($id);
+            if (auth()->user()->isAdmin()) {
+                $conference = Conference::withoutGlobalScope('notRejected')->findOrFail($id);
+            } else {
+                $conference = Conference::findOrFail($id);
+            }
         } catch (Exception $e) {
             return redirect('/');
         }

--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -78,6 +78,10 @@ class Conference extends UuidBase
                 $conference->is_approved = true;
             }
         });
+
+        static::addGlobalScope('notRejected', function ($builder) {
+            $builder->whereNull('rejected_at');
+        });
     }
 
     public function author()

--- a/app/Notifications/ConferenceImporterError.php
+++ b/app/Notifications/ConferenceImporterError.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Notifications;
+
+use Exception;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+
+class ConferenceImporterError extends Notification
+{
+    use Queueable;
+
+    protected $message;
+
+    public function __construct(Exception $exception)
+    {
+        $this->message = $exception->getMessage();
+    }
+
+    public function via($notifiable)
+    {
+        return ['slack'];
+    }
+
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage())
+            ->attachment(function ($attachment) {
+                $attachment
+                    ->title('Conference importer encountered an error')
+                    ->content("Message: {$this->message}")
+                    ->timestamp(Carbon::now());
+            });
+    }
+}

--- a/app/Notifications/ConferenceImporterFinished.php
+++ b/app/Notifications/ConferenceImporterFinished.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+
+class ConferenceImporterFinished extends Notification
+{
+    use Queueable;
+
+    public function via($notifiable)
+    {
+        return ['slack'];
+    }
+
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage())
+            ->attachment(function ($attachment) {
+                $attachment
+                    ->title('Conference importer finished')
+                    ->timestamp(Carbon::now());
+            });
+    }
+}

--- a/app/Notifications/ConferenceImporterRejection.php
+++ b/app/Notifications/ConferenceImporterRejection.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Conference;
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Notification;
+
+class ConferenceImporterRejection extends Notification
+{
+    use Queueable;
+
+    protected $conference;
+
+    public function __construct(Conference $conference)
+    {
+        $this->conference = $conference;
+    }
+
+    public function via($notifiable)
+    {
+        return ['slack'];
+    }
+
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage())
+            ->attachment(function ($attachment) {
+                $attachment
+                    ->title('Conference importer rejected a conference')
+                    ->action($conference->title, $conference->link)
+                    ->timestamp(Carbon::now());
+            });
+    }
+}

--- a/app/Notifications/ConferenceImporterStarted.php
+++ b/app/Notifications/ConferenceImporterStarted.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+
+class ConferenceImporterStarted extends Notification
+{
+    use Queueable;
+
+    public function via($notifiable)
+    {
+        return ['slack'];
+    }
+
+    public function toSlack($notifiable)
+    {
+        return (new SlackMessage())
+            ->attachment(function ($attachment) {
+                $attachment
+                    ->title('Conference importer started')
+                    ->timestamp(Carbon::now());
+            });
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,9 +2,11 @@
 
 namespace App\Providers;
 
+use App\CallingAllPapers\Client;
 use App\Handlers\Events\SlackSubscriber;
 use Collective\Html\FormBuilder;
 use Exception;
+use GuzzleHttp\Client as GuzzleClient;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
@@ -75,5 +77,19 @@ class AppServiceProvider extends ServiceProvider
                 csrf_token()
             );
         });
+
+        $this->registerCallingAllPapersClient();
+    }
+
+    public function registerCallingAllPapersClient()
+    {
+        $this->app->when(Client::class)
+            ->needs(GuzzleClient::class)
+            ->give(function () {
+                return new GuzzleClient([
+                    'headers'  => ['User-Agent' => 'Symposium CLI'],
+                    'base_uri' => 'https://api.callingallpapers.com/v1/cfp',
+                ]);
+            });
     }
 }

--- a/database/factories/ConferenceFactory.php
+++ b/database/factories/ConferenceFactory.php
@@ -49,6 +49,13 @@ class ConferenceFactory extends Factory
         ]);
     }
 
+    public function rejected()
+    {
+        return $this->state([
+            'rejected_at' => $this->faker->dateTime,
+        ]);
+    }
+
     public function notApproved()
     {
         return $this->state([

--- a/database/migrations/2022_11_11_132039_add_rejected_at_column_to_conferences_table.php
+++ b/database/migrations/2022_11_11_132039_add_rejected_at_column_to_conferences_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::table('conferences', function (Blueprint $table) {
+            $table->dateTime('rejected_at')->after('cfp_ends_at')->nullable();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('conferences', function (Blueprint $table) {
+            $table->dropColumn('rejected_at');
+        });
+    }
+};

--- a/tests/Feature/CallingAllPapersConferenceImporterTest.php
+++ b/tests/Feature/CallingAllPapersConferenceImporterTest.php
@@ -2,61 +2,22 @@
 
 namespace Tests\Feature;
 
-use App\CallingAllPapers\Client;
 use App\CallingAllPapers\ConferenceImporter;
-use App\CallingAllPapers\Event;
 use App\Models\Conference;
 use App\Services\Geocoder;
-use Mockery as m;
-use stdClass;
+use Tests\MocksCallingAllPapers;
 use Tests\TestCase;
 
 class CallingAllPapersConferenceImporterTest extends TestCase
 {
-    private $eventId = 'abcdef1234567890abcdef1234567890abcdef122017';
-
-    private $eventStub;
+    use MocksCallingAllPapers;
 
     /** @before */
     public function prepareEventStub()
     {
         parent::setUp();
 
-        $this->eventStub = $this->stubEvent();
-    }
-
-    public function stubEvent()
-    {
-        $_rel = new stdClass();
-        $_rel->cfp_uri = "v1/cfp/{$this->eventId}";
-
-        $event = new stdClass();
-
-        $event->_rel = $_rel;
-        $event->name = 'ABC conference';
-        $event->description = 'The greatest conference ever.';
-        $event->eventUri = 'https://www.example.com/';
-        $event->uri = 'https://cfp.example.com/';
-        $event->dateCfpStart = '2017-08-20T00:00:00-04:00';
-        $event->dateCfpEnd = '2017-09-22T00:00:00-04:00';
-        $event->dateEventStart = '2017-10-20T00:00:00-04:00';
-        $event->dateEventEnd = '2017-12-22T00:00:00-04:00';
-
-        return Event::createFromApiObject($event);
-    }
-
-    public function mockClient($event = null)
-    {
-        if (! $event) {
-            $event = $this->eventStub;
-        }
-
-        $mockClient = m::mock(Client::class);
-
-        $mockClient->shouldReceive('getEvents')->andReturn([$event]);
-        app()->instance(Client::class, $mockClient);
-
-        return $mockClient;
+        $this->stubEvent();
     }
 
     /** @test */

--- a/tests/Feature/CallingAllPapersConferenceImporterTest.php
+++ b/tests/Feature/CallingAllPapersConferenceImporterTest.php
@@ -317,8 +317,9 @@ class CallingAllPapersConferenceImporterTest extends TestCase
         $event->dateCfpEnd = '2017-09-02T00:00:00-04:00';
         $importer->import($event);
 
-        $this->assertEquals(1, Conference::count());
-        $conference = Conference::where('calling_all_papers_id', 'fake-cfp-id')->first();
+        $conference = Conference::withoutGlobalScope('notRejected')
+            ->where('calling_all_papers_id', 'fake-cfp-id')
+            ->first();
         $this->assertNotNull($conference);
         $this->assertNotNull($conference->rejected_at);
     }
@@ -335,8 +336,9 @@ class CallingAllPapersConferenceImporterTest extends TestCase
         $event->dateEventEnd = '2020-10-01T00:00:00-04:00';
         $importer->import($event);
 
-        $this->assertEquals(1, Conference::count());
-        $conference = Conference::where('calling_all_papers_id', 'fake-cfp-id')->first();
+        $conference = Conference::withoutGlobalScope('notRejected')
+            ->where('calling_all_papers_id', 'fake-cfp-id')
+            ->first();
         $this->assertNotNull($conference);
         $this->assertNotNull($conference->rejected_at);
     }
@@ -353,8 +355,9 @@ class CallingAllPapersConferenceImporterTest extends TestCase
         $event->dateCfpEnd = '2017-06-01T00:00:00-04:00';
         $importer->import($event);
 
-        $this->assertEquals(1, Conference::count());
-        $conference = Conference::where('calling_all_papers_id', 'fake-cfp-id')->first();
+        $conference = Conference::withoutGlobalScope('notRejected')
+            ->where('calling_all_papers_id', 'fake-cfp-id')
+            ->first();
         $this->assertNotNull($conference);
         $this->assertNotNull($conference->rejected_at);
     }

--- a/tests/Feature/CallingAllPapersConferenceImporterTest.php
+++ b/tests/Feature/CallingAllPapersConferenceImporterTest.php
@@ -306,45 +306,57 @@ class CallingAllPapersConferenceImporterTest extends TestCase
     }
 
     /** @test */
-    public function conferences_with_cfp_end_after_conference_start_are_not_imported()
+    public function conferences_with_cfp_end_after_conference_start_are_rejected()
     {
         $this->mockClient();
 
         $importer = new ConferenceImporter(1);
         $event = $this->eventStub;
+        $event->id = 'fake-cfp-id';
         $event->dateEventStart = '2017-09-01T00:00:00-04:00';
         $event->dateCfpEnd = '2017-09-02T00:00:00-04:00';
         $importer->import($event);
 
-        $this->assertEquals(0, Conference::count());
+        $this->assertEquals(1, Conference::count());
+        $conference = Conference::where('calling_all_papers_id', 'fake-cfp-id')->first();
+        $this->assertNotNull($conference);
+        $this->assertNotNull($conference->rejected_at);
     }
 
     /** @test */
-    public function conferences_with_over_2_year_duration_are_not_imported()
+    public function conferences_with_over_2_year_duration_are_rejected()
     {
         $this->mockClient();
 
         $importer = new ConferenceImporter(1);
         $event = $this->eventStub;
+        $event->id = 'fake-cfp-id';
         $event->dateEventStart = '2017-10-01T00:00:00-04:00';
         $event->dateEventEnd = '2020-10-01T00:00:00-04:00';
         $importer->import($event);
 
-        $this->assertEquals(0, Conference::count());
+        $this->assertEquals(1, Conference::count());
+        $conference = Conference::where('calling_all_papers_id', 'fake-cfp-id')->first();
+        $this->assertNotNull($conference);
+        $this->assertNotNull($conference->rejected_at);
     }
 
     /** @test */
-    public function conferences_with_cfp_duration_over_2_years_are_not_imported()
+    public function conferences_with_cfp_duration_over_2_years_are_rejected()
     {
         $this->mockClient();
 
         $importer = new ConferenceImporter(1);
         $event = $this->eventStub;
+        $event->id = 'fake-cfp-id';
         $event->dateCfpStart = '2014-06-01T00:00:00-04:00';
         $event->dateCfpEnd = '2017-06-01T00:00:00-04:00';
         $importer->import($event);
 
-        $this->assertEquals(0, Conference::count());
+        $this->assertEquals(1, Conference::count());
+        $conference = Conference::where('calling_all_papers_id', 'fake-cfp-id')->first();
+        $this->assertNotNull($conference);
+        $this->assertNotNull($conference->rejected_at);
     }
 
     /** @test */

--- a/tests/Feature/ConferenceIssuesTest.php
+++ b/tests/Feature/ConferenceIssuesTest.php
@@ -4,7 +4,6 @@ namespace Tests\Feature;
 
 use App\Models\Conference;
 use App\Models\ConferenceIssue;
-use App\Models\TightenSlack;
 use App\Models\User;
 use App\Notifications\ConferenceIssueReported;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -22,7 +21,6 @@ class ConferenceIssuesTest extends TestCase
         Notification::fake();
         $user = User::factory()->create();
         $conference = Conference::factory()->create();
-        $tightenSlack = new TightenSlack();
 
         $response = $this->actingAs($user)
             ->post(route('conferences.issues.store', $conference), [
@@ -39,7 +37,7 @@ class ConferenceIssuesTest extends TestCase
             'reason' => 'spam',
             'note' => 'this conference is spam',
         ]);
-        Notification::assertSentTo($tightenSlack, ConferenceIssueReported::class);
+        Notification::assertSentToTightenSlack(ConferenceIssueReported::class);
     }
 
     /** @test */

--- a/tests/Feature/ConferenceTest.php
+++ b/tests/Feature/ConferenceTest.php
@@ -938,4 +938,26 @@ class ConferenceTest extends TestCase
 
         $this->assertFalse($conference->isFlagged());
     }
+
+    /** @test */
+    function rejected_conferences_are_not_found()
+    {
+        $user = User::factory()->create();
+        $conference = Conference::factory()->rejected()->create();
+
+        $response = $this->actingAs($user)->get($conference->link);
+
+        $response->assertNotFound();
+    }
+
+    /** @test */
+    function admins_can_see_rejected_conferences()
+    {
+        $user = User::factory()->admin()->create();
+        $conference = Conference::factory()->rejected()->create();
+
+        $response = $this->actingAs($user)->get($conference->link);
+
+        $response->assertSuccessful();
+    }
 }

--- a/tests/Feature/SyncCallingAllPapersEventsTest.php
+++ b/tests/Feature/SyncCallingAllPapersEventsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Notifications\ConferenceImporterFinished;
 use App\Notifications\ConferenceImporterStarted;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
@@ -26,5 +27,6 @@ class SyncCallingAllPapersEventsTest extends TestCase
         Artisan::call('callingallpapers:sync');
 
         Notification::assertSentToTightenSlack(ConferenceImporterStarted::class);
+        Notification::assertSentToTightenSlack(ConferenceImporterFinished::class);
     }
 }

--- a/tests/Feature/SyncCallingAllPapersEventsTest.php
+++ b/tests/Feature/SyncCallingAllPapersEventsTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Notifications\ConferenceImporterError;
 use App\Notifications\ConferenceImporterFinished;
 use App\Notifications\ConferenceImporterStarted;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -28,5 +29,19 @@ class SyncCallingAllPapersEventsTest extends TestCase
 
         Notification::assertSentToTightenSlack(ConferenceImporterStarted::class);
         Notification::assertSentToTightenSlack(ConferenceImporterFinished::class);
+    }
+
+    /** @test */
+    function notifying_slack_when_command_errors()
+    {
+        Notification::fake();
+        $this->stubEvent();
+        $this->mockClientWithError();
+
+        Artisan::call('callingallpapers:sync');
+
+        Notification::assertSentToTightenSlack(ConferenceImporterStarted::class);
+        Notification::assertSentToTightenSlack(ConferenceImporterError::class);
+        Notification::assertNotSentToTightenSlack(ConferenceImporterFinished::class);
     }
 }

--- a/tests/Feature/SyncCallingAllPapersEventsTest.php
+++ b/tests/Feature/SyncCallingAllPapersEventsTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Notifications\ConferenceImporterError;
 use App\Notifications\ConferenceImporterFinished;
+use App\Notifications\ConferenceImporterRejection;
 use App\Notifications\ConferenceImporterStarted;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
@@ -43,5 +44,21 @@ class SyncCallingAllPapersEventsTest extends TestCase
         Notification::assertSentToTightenSlack(ConferenceImporterStarted::class);
         Notification::assertSentToTightenSlack(ConferenceImporterError::class);
         Notification::assertNotSentToTightenSlack(ConferenceImporterFinished::class);
+    }
+
+    /** @test */
+    function notifying_slack_when_conference_is_rejected()
+    {
+        Notification::fake();
+        $this->stubEvent();
+        $this->eventStub->dateEventStart = '2017-10-01T00:00:00-04:00';
+        $this->eventStub->dateEventEnd = '2020-10-01T00:00:00-04:00';
+        $this->mockClient();
+
+        Artisan::call('callingallpapers:sync');
+
+        Notification::assertSentToTightenSlack(ConferenceImporterStarted::class);
+        Notification::assertSentToTightenSlack(ConferenceImporterRejection::class);
+        Notification::assertSentToTightenSlack(ConferenceImporterFinished::class);
     }
 }

--- a/tests/Feature/SyncCallingAllPapersEventsTest.php
+++ b/tests/Feature/SyncCallingAllPapersEventsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\TightenSlack;
+use App\Notifications\ConferenceImporterStarted;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Notification;
+use Tests\MocksCallingAllPapers;
+use Tests\TestCase;
+
+class SyncCallingAllPapersEventsTest extends TestCase
+{
+    use RefreshDatabase;
+    use MocksCallingAllPapers;
+
+    protected $eventStub;
+
+    /** @test */
+    function notifying_slack_when_command_starts_and_ends()
+    {
+        Notification::fake();
+        $this->stubEvent();
+        $this->mockClient();
+        $tightenSlack = new TightenSlack();
+
+        Artisan::call('callingallpapers:sync');
+
+        Notification::assertSentTo($tightenSlack, ConferenceImporterStarted::class);
+    }
+}

--- a/tests/Feature/SyncCallingAllPapersEventsTest.php
+++ b/tests/Feature/SyncCallingAllPapersEventsTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature;
 
-use App\Models\TightenSlack;
 use App\Notifications\ConferenceImporterStarted;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
@@ -23,10 +22,9 @@ class SyncCallingAllPapersEventsTest extends TestCase
         Notification::fake();
         $this->stubEvent();
         $this->mockClient();
-        $tightenSlack = new TightenSlack();
 
         Artisan::call('callingallpapers:sync');
 
-        Notification::assertSentTo($tightenSlack, ConferenceImporterStarted::class);
+        Notification::assertSentToTightenSlack(ConferenceImporterStarted::class);
     }
 }

--- a/tests/MocksCallingAllPapers.php
+++ b/tests/MocksCallingAllPapers.php
@@ -4,6 +4,7 @@ namespace Tests;
 
 use App\CallingAllPapers\Client;
 use App\CallingAllPapers\Event;
+use Exception;
 use Mockery;
 use stdClass;
 
@@ -22,6 +23,17 @@ trait MocksCallingAllPapers
         $mockClient = Mockery::mock(Client::class);
 
         $mockClient->shouldReceive('getEvents')->andReturn([$event]);
+        app()->instance(Client::class, $mockClient);
+
+        return $mockClient;
+    }
+
+    public function mockClientWithError()
+    {
+        $mockClient = Mockery::mock(Client::class);
+
+        $mockClient->shouldReceive('getEvents')
+            ->andThrow(Exception::class, 'Test exception');
         app()->instance(Client::class, $mockClient);
 
         return $mockClient;

--- a/tests/MocksCallingAllPapers.php
+++ b/tests/MocksCallingAllPapers.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests;
+
+use App\CallingAllPapers\Client;
+use App\CallingAllPapers\Event;
+use Mockery;
+use stdClass;
+
+trait MocksCallingAllPapers
+{
+    protected $eventId = 'abcdef1234567890abcdef1234567890abcdef122017';
+
+    protected $eventStub;
+
+    public function mockClient($event = null)
+    {
+        if (! $event) {
+            $event = $this->eventStub;
+        }
+
+        $mockClient = Mockery::mock(Client::class);
+
+        $mockClient->shouldReceive('getEvents')->andReturn([$event]);
+        app()->instance(Client::class, $mockClient);
+
+        return $mockClient;
+    }
+
+    public function stubEvent()
+    {
+        $_rel = new stdClass();
+        $_rel->cfp_uri = "v1/cfp/{$this->eventId}";
+
+        $event = new stdClass();
+
+        $event->_rel = $_rel;
+        $event->name = 'ABC conference';
+        $event->description = 'The greatest conference ever.';
+        $event->eventUri = 'https://www.example.com/';
+        $event->uri = 'https://cfp.example.com/';
+        $event->dateCfpStart = '2017-08-20T00:00:00-04:00';
+        $event->dateCfpEnd = '2017-09-22T00:00:00-04:00';
+        $event->dateEventStart = '2017-10-20T00:00:00-04:00';
+        $event->dateEventEnd = '2017-12-22T00:00:00-04:00';
+
+        $this->eventStub = Event::createFromApiObject($event);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,5 +21,9 @@ abstract class TestCase extends BaseTestCase
         NotificationFake::macro('assertSentToTightenSlack', function ($notification) {
             $this->assertSentTo(new TightenSlack(), $notification);
         });
+
+        NotificationFake::macro('assertNotSentToTightenSlack', function ($notification) {
+            $this->assertNotSentTo(new TightenSlack(), $notification);
+        });
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,7 +14,7 @@ abstract class TestCase extends BaseTestCase
 
     public $baseUrl = 'http://symposium.test';
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,8 +2,10 @@
 
 namespace Tests;
 
+use App\Models\TightenSlack;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Testing\Fakes\NotificationFake;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -11,4 +13,13 @@ abstract class TestCase extends BaseTestCase
     use LazilyRefreshDatabase;
 
     public $baseUrl = 'http://symposium.test';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        NotificationFake::macro('assertSentToTightenSlack', function ($notification) {
+            $this->assertSentTo(new TightenSlack(), $notification);
+        });
+    }
 }


### PR DESCRIPTION
This PR improves visibility of the conference importer with the following updates:
- Slack will be notified when the importer starts, finishes, rejects a conference or encounters an error
- Conferences that fail validation will now be persisted but marked as rejected
- Rejected conferences cannot be seen other than by admin
- A bug in `App\CallingAllPapers\Client` where the wrong `Event` class was imported has been fixed