### PR TITLE
Import missing class

### DIFF
--- a/app/Notifications/ConferenceImporterRejection.php
+++ b/app/Notifications/ConferenceImporterRejection.php
@@ -4,6 +4,7 @@ namespace App\Notifications;
 
 use App\Models\Conference;
 use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Carbon;
 


### PR DESCRIPTION
This PR imports the missing `SlackMessage` to `ConferenceImporterRejection`.