### PR TITLE
Restart conference importer

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -15,8 +15,8 @@ class Kernel extends ConsoleKernel
 
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('callingallpapers:sync')
-        //     ->hourly();
+        $schedule->command('callingallpapers:sync')
+            ->hourly();
 
         // $schedule->command('tweet:cfpDates')
         //      ->dailyAt('08:00')

--- a/app/Notifications/ConferenceImporterInactive.php
+++ b/app/Notifications/ConferenceImporterInactive.php
@@ -5,6 +5,7 @@ namespace App\Notifications;
 use Illuminate\Bus\Queueable;
 use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
+use Illuminate\Support\Carbon;
 
 class ConferenceImporterInactive extends Notification
 {


### PR DESCRIPTION
This PR restarts the hourly conference importer as well as fixes a bug in the `ConferenceImporterInactive` where the `Carbon` import was missing.