### PR TITLE
Ignore invalid dates in the conference importer

### DIFF
--- a/app/CallingAllPapers/ConferenceImporter.php
+++ b/app/CallingAllPapers/ConferenceImporter.php
@@ -6,6 +6,7 @@ use App\Exceptions\InvalidAddressGeocodingException;
 use App\Models\Conference;
 use App\Services\Geocoder;
 use Carbon\Carbon;
+use Carbon\Exceptions\InvalidFormatException;
 use DateTime;
 use Illuminate\Support\Facades\Validator;
 
@@ -27,7 +28,11 @@ class ConferenceImporter
             return null;
         }
 
-        return Carbon::createFromFormat(DateTime::ISO8601, $dateFromApi);
+        try {
+            return Carbon::createFromFormat(DateTime::ISO8601, $dateFromApi);
+        } catch (InvalidFormatException $e) {
+            return null;
+        }
     }
 
     public function import(Event $event)

--- a/tests/Feature/CallingAllPapersConferenceImporterTest.php
+++ b/tests/Feature/CallingAllPapersConferenceImporterTest.php
@@ -181,6 +181,29 @@ class CallingAllPapersConferenceImporterTest extends TestCase
     }
 
     /** @test */
+    public function invalid_dates_are_ignored()
+    {
+        $event = $this->eventStub;
+
+        $event->dateCfpStart = 'invalid';
+        $event->dateCfpEnd = 'invalid';
+        $event->dateEventStart = 'invalid';
+        $event->dateEventEnd = 'invalid';
+
+        $this->mockClient($event);
+
+        $importer = new ConferenceImporter(1);
+        $importer->import($event);
+
+        $conference = Conference::first();
+
+        $this->assertNull($conference->starts_at);
+        $this->assertNull($conference->ends_at);
+        $this->assertNull($conference->cfp_starts_at);
+        $this->assertNull($conference->cfp_ends_at);
+    }
+
+    /** @test */
     public function it_imports_zero_in_latitude_or_longitude_as_null()
     {
         $event = $this->eventStub;


### PR DESCRIPTION
This PR prevents the conference importer from silently failing by catching Carbon's `InvalidFormatException` and returning null for invalid dates.