### PR TITLE
Run integration tests on GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
                 GITHUB_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
 
             - name: Integration Tests
-              run: vendor/bin/phpunit tests/integration
+              run: vendor/bin/phpunit ./tests/integration
               env:
                 GITHUB_CLIENT_ID: ${{ secrets.CLIENT_ID }}
                 GITHUB_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
 
             - name: Integration Tests
               run: pwd
+              working-directory: ./tests
               env:
                 GITHUB_CLIENT_ID: ${{ secrets.CLIENT_ID }}
                 GITHUB_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,3 +36,10 @@ jobs:
               env:
                 GITHUB_CLIENT_ID: ${{ secrets.CLIENT_ID }}
                 GITHUB_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+
+            - name: Integration Tests
+              run: vendor/bin/phpunit tests/integration
+              env:
+                GITHUB_CLIENT_ID: ${{ secrets.CLIENT_ID }}
+                GITHUB_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
+                GOOGLE_MAPS_API_KEY: ${{ secrets.GOOGLE_MAPS_API_KEY }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,7 @@ jobs:
                 GITHUB_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
 
             - name: Integration Tests
-              run: vendor/bin/phpunit ./integration
-              working-directory: ./tests
+              run: vendor/bin/phpunit tests/Integration
               env:
                 GITHUB_CLIENT_ID: ${{ secrets.CLIENT_ID }}
                 GITHUB_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
                 GITHUB_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
 
             - name: Integration Tests
-              run: vendor/bin/phpunit ./tests/integration
+              run: pwd
               env:
                 GITHUB_CLIENT_ID: ${{ secrets.CLIENT_ID }}
                 GITHUB_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
                 GITHUB_CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
 
             - name: Integration Tests
-              run: pwd
+              run: vendor/bin/phpunit ./integration
               working-directory: ./tests
               env:
                 GITHUB_CLIENT_ID: ${{ secrets.CLIENT_ID }}


### PR DESCRIPTION
This PR updates the GitHub test action to run the tests in `tests/integration`.