### PR TITLE
Speaker package display updates

### DIFF
--- a/app/Casts/SpeakerPackage.php
+++ b/app/Casts/SpeakerPackage.php
@@ -22,7 +22,7 @@ class SpeakerPackage implements Arrayable, Castable
 
     private $currency;
 
-    public function __construct($package)
+    public function __construct(array $package)
     {
         $this->categories = Arr::except($package, ['currency']);
         $this->currency = $package['currency'] ?? null;

--- a/app/Casts/SpeakerPackage.php
+++ b/app/Casts/SpeakerPackage.php
@@ -59,16 +59,20 @@ class SpeakerPackage implements Arrayable, Castable
         });
     }
 
-    public function toDecimal()
+    public function toDecimal($category)
     {
-        if (! $this->currency) {
-            return collect();
+        if (! $this->currency || ! array_key_exists($category, $this->categories)) {
+            return;
         };
 
-        return collect($this->categories)->map(function ($item) {
+        return with($this->categories[$category], function ($amount) {
+            if (! $amount > 0) {
+                return;
+            }
+
             $currency = $this->currency;
 
-            return $item > 0 ? Money::$currency($item)->formatByDecimal() : null;
+            return Money::$currency($amount)->formatByDecimal();
         });
     }
 

--- a/app/Casts/SpeakerPackage.php
+++ b/app/Casts/SpeakerPackage.php
@@ -104,13 +104,16 @@ class SpeakerPackage implements Arrayable, Castable
         // then we want to use the appropriate parser
         foreach (SpeakerPackage::CATEGORIES as $category) {
             $itemHasPunctuation = Str::of($this->$category)->contains([',', '.']);
-
-            $speakerPackage[$category] = Money::parse(
+            $amount = Money::parse(
                 $this->$category,
                 $this->currency,
                 ! $itemHasPunctuation,
-                App::currentLocale()
+                App::currentLocale(),
             )->getAmount();
+
+            if ($amount > 0) {
+                $speakerPackage[$category] = $amount;
+            }
         }
 
         return $speakerPackage;

--- a/app/Casts/SpeakerPackage.php
+++ b/app/Casts/SpeakerPackage.php
@@ -11,9 +11,9 @@ use Illuminate\Support\Arr;
 class SpeakerPackage implements Arrayable, Castable
 {
     public const CATEGORIES = [
-        'travel',
-        'hotel',
         'food',
+        'hotel',
+        'travel',
     ];
 
     private $categories;

--- a/app/Casts/SpeakerPackage.php
+++ b/app/Casts/SpeakerPackage.php
@@ -96,11 +96,17 @@ class SpeakerPackage implements Arrayable, Castable
             'currency' => $this->currency,
         ];
 
-        // Since users have the ability to enter punctuation or not, then we want to use the appropriate parser
+        // Since users have the ability to enter punctuation or not,
+        // then we want to use the appropriate parser
         foreach (SpeakerPackage::CATEGORIES as $category) {
             $itemHasPunctuation = Str::of($this->$category)->contains([',', '.']);
 
-            $speakerPackage[$category] = Money::parse($this->$category, $this->currency, ! $itemHasPunctuation, App::currentLocale())->getAmount();
+            $speakerPackage[$category] = Money::parse(
+                $this->$category,
+                $this->currency,
+                ! $itemHasPunctuation,
+                App::currentLocale()
+            )->getAmount();
         }
 
         return $speakerPackage;

--- a/app/Casts/SpeakerPackage.php
+++ b/app/Casts/SpeakerPackage.php
@@ -41,6 +41,10 @@ class SpeakerPackage implements Arrayable, Castable
 
             public function set($model, $key, $value, $attributes)
             {
+                if (! $value) {
+                    return null;
+                }
+
                 return json_encode($value->toDatabase());
             }
         };

--- a/app/Casts/SpeakerPackage.php
+++ b/app/Casts/SpeakerPackage.php
@@ -41,18 +41,7 @@ class SpeakerPackage implements Arrayable, Castable
 
             public function set($model, $key, $value, $attributes)
             {
-                $speakerPackage = [
-                    'currency' => $value->currency,
-                ];
-
-                // Since users have the ability to enter punctuation or not, then we want to use the appropriate parser
-                foreach (SpeakerPackage::CATEGORIES as $category) {
-                    $itemHasPunctuation = Str::of($value->$category)->contains([',', '.']);
-
-                    $speakerPackage[$category] = Money::parse($value->$category, $value->currency, ! $itemHasPunctuation, App::currentLocale())->getAmount();
-                }
-
-                return json_encode($speakerPackage);
+                return json_encode($value->toDatabase());
             }
         };
     }
@@ -93,12 +82,28 @@ class SpeakerPackage implements Arrayable, Castable
             return [];
         };
 
-        return array_merge($this->categories, ['currency' => $this->currency]);
+        return array_merge(['currency' => $this->currency], $this->categories);
     }
 
     public function count()
     {
         return count($this->categories);
+    }
+
+    public function toDatabase()
+    {
+        $speakerPackage = [
+            'currency' => $this->currency,
+        ];
+
+        // Since users have the ability to enter punctuation or not, then we want to use the appropriate parser
+        foreach (SpeakerPackage::CATEGORIES as $category) {
+            $itemHasPunctuation = Str::of($this->$category)->contains([',', '.']);
+
+            $speakerPackage[$category] = Money::parse($this->$category, $this->currency, ! $itemHasPunctuation, App::currentLocale())->getAmount();
+        }
+
+        return $speakerPackage;
     }
 
     public function __get($value)

--- a/app/Casts/SpeakerPackage.php
+++ b/app/Casts/SpeakerPackage.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Models;
+namespace App\Casts;
 
 use Cknow\Money\Money;
 use Illuminate\Contracts\Database\Eloquent\Castable;
@@ -10,6 +10,12 @@ use Illuminate\Support\Arr;
 
 class SpeakerPackage implements Arrayable, Castable
 {
+    public const CATEGORIES = [
+        'travel',
+        'hotel',
+        'food',
+    ];
+
     private $categories;
 
     private $currency;

--- a/app/Http/Controllers/ConferencesController.php
+++ b/app/Http/Controllers/ConferencesController.php
@@ -122,7 +122,6 @@ class ConferencesController extends Controller
         return view('conferences.edit', [
             'conference' => $conference,
             'currencies' => Currency::all(),
-            'package' => $conference->speaker_package->toDecimal(),
         ]);
     }
 

--- a/app/Http/Controllers/ConferencesController.php
+++ b/app/Http/Controllers/ConferencesController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Casts\SpeakerPackage;
 use App\Http\Requests\SaveConferenceRequest;
 use App\Models\Conference;
 use App\Services\Currency;
@@ -72,7 +71,6 @@ class ConferencesController extends Controller
     {
         $conference = Conference::create(array_merge($request->validated(), [
             'author_id' => auth()->user()->id,
-            'speaker_package' => new SpeakerPackage($request->speaker_package ? $request->safe()->speaker_package : null),
         ]));
 
         Event::dispatch('new-conference', [$conference]);
@@ -134,13 +132,7 @@ class ConferencesController extends Controller
             return redirect('/');
         }
 
-        // Save
-        $conference->fill(array_merge(
-            $request->validated(),
-            [
-                'speaker_package' => new SpeakerPackage($request->safe()->speaker_package),
-            ],
-        ));
+        $conference->fill($request->validated());
 
         if (auth()->user()->isAdmin()) {
             $conference->is_shared = $request->input('is_shared');

--- a/app/Http/Controllers/ConferencesController.php
+++ b/app/Http/Controllers/ConferencesController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Casts\SpeakerPackage;
 use App\Http\Requests\SaveConferenceRequest;
 use App\Models\Conference;
 use App\Services\Currency;
@@ -224,10 +225,10 @@ class ConferencesController extends Controller
         ];
 
         // Since users have the ability to enter punctuation or not, then we want to use the appropriate parser
-        foreach (['travel', 'food', 'hotel'] as $item) {
-            $itemHasPunctuation = Str::of($package[$item])->contains([',', '.']);
+        foreach (SpeakerPackage::CATEGORIES as $category) {
+            $itemHasPunctuation = Str::of($package[$category])->contains([',', '.']);
 
-            $speakerPackage[$item] = Money::parse($package[$item], $package['currency'], ! $itemHasPunctuation, App::currentLocale())->getAmount();
+            $speakerPackage[$category] = Money::parse($package[$category], $package['currency'], ! $itemHasPunctuation, App::currentLocale())->getAmount();
         }
 
         return $speakerPackage;

--- a/app/Http/Requests/SaveConferenceRequest.php
+++ b/app/Http/Requests/SaveConferenceRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Casts\SpeakerPackage;
 use App\Rules\ValidAmountForCurrentLocale;
 use Cknow\Money\Money;
 use Illuminate\Foundation\Http\FormRequest;
@@ -58,5 +59,19 @@ class SaveConferenceRequest extends FormRequest
                 new ValidAmountForCurrentLocale(),
             ],
         ];
+    }
+
+    public function validated($key = null, $default = null)
+    {
+        return data_get($this->withSpeakerPackage(), $key, $default);
+    }
+
+    private function withSpeakerPackage()
+    {
+        return array_merge($this->validator->validated(), [
+            'speaker_package' => new SpeakerPackage(
+                parent::validated('speaker_package'),
+            ),
+        ]);
     }
 }

--- a/app/Http/Requests/SaveConferenceRequest.php
+++ b/app/Http/Requests/SaveConferenceRequest.php
@@ -66,7 +66,7 @@ class SaveConferenceRequest extends FormRequest
     private function withSpeakerPackage()
     {
         $speakerPackage = new SpeakerPackage(
-            parent::validated('speaker_package'),
+            parent::validated('speaker_package') ?? [],
         );
 
         return array_merge($this->validator->validated(), [

--- a/app/Http/Requests/SaveConferenceRequest.php
+++ b/app/Http/Requests/SaveConferenceRequest.php
@@ -68,10 +68,12 @@ class SaveConferenceRequest extends FormRequest
 
     private function withSpeakerPackage()
     {
+        $speakerPackage = new SpeakerPackage(
+            parent::validated('speaker_package'),
+        );
+
         return array_merge($this->validator->validated(), [
-            'speaker_package' => new SpeakerPackage(
-                parent::validated('speaker_package'),
-            ),
+            'speaker_package' => $speakerPackage->count() ? $speakerPackage : null,
         ]);
     }
 }

--- a/app/Http/Requests/SaveConferenceRequest.php
+++ b/app/Http/Requests/SaveConferenceRequest.php
@@ -46,18 +46,15 @@ class SaveConferenceRequest extends FormRequest
                     $fail($attribute . ' must be a valid currency type.');
                 };
             },
-            'speaker_package.travel' => [
-                'nullable',
-                new ValidAmountForCurrentLocale(),
-            ],
-            'speaker_package.food' => [
-                'nullable',
-                new ValidAmountForCurrentLocale(),
-            ],
-            'speaker_package.hotel' => [
-                'nullable',
-                new ValidAmountForCurrentLocale(),
-            ],
+            ...collect(SpeakerPackage::CATEGORIES)
+                ->mapWithKeys(function ($category) {
+                    return [
+                        "speaker_package.{$category}" => [
+                            'nullable',
+                            new ValidAmountForCurrentLocale(),
+                        ],
+                    ];
+                }),
         ];
     }
 

--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -22,6 +22,12 @@ class Conference extends UuidBase
     use HasFactory;
     use SoftDeletes;
 
+    public const SPEAKER_PACKAGE_ITEMS = [
+        'travel',
+        'hotel',
+        'food',
+    ];
+
     protected $table = 'conferences';
 
     protected $guarded = [

--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Casts\Coordinates;
+use App\Casts\SpeakerPackage;
 use App\Casts\Url;
 use App\Models\Acceptance;
 use App\Models\ConferenceIssue;
@@ -21,12 +22,6 @@ class Conference extends UuidBase
 {
     use HasFactory;
     use SoftDeletes;
-
-    public const SPEAKER_PACKAGE_ITEMS = [
-        'travel',
-        'hotel',
-        'food',
-    ];
 
     protected $table = 'conferences';
 

--- a/app/Rules/ValidAmountForCurrentLocale.php
+++ b/app/Rules/ValidAmountForCurrentLocale.php
@@ -16,7 +16,8 @@ class ValidAmountForCurrentLocale implements DataAwareRule, InvokableRule
     public function __invoke($attribute, $value, $fail)
     {
         if (! preg_match('/\d+([.,]?\d*)*/', $value)) {
-            $fail($attribute . ' amount is invalid. Please check formatting and try again.');
+            $fail($this->formatErrorMessage($attribute));
+            return;
         }
 
         $valueHasPunctuation = Str::of($value)->contains([',', '.']);
@@ -24,7 +25,7 @@ class ValidAmountForCurrentLocale implements DataAwareRule, InvokableRule
         try {
             Money::parse($value, $this->data['speaker_package']['currency'], ! $valueHasPunctuation, App::currentLocale())->getAmount();
         } catch (ParserException $e) {
-            $fail($attribute . ' amount is invalid. Please check formatting and try again.');
+            $fail($this->formatErrorMessage($attribute));
         }
     }
 
@@ -33,5 +34,14 @@ class ValidAmountForCurrentLocale implements DataAwareRule, InvokableRule
         $this->data = $data;
 
         return $this;
+    }
+
+    private function formatErrorMessage($attribute)
+    {
+        return str('{attribute} amount is invalid. Please update formatting and try again.')
+            ->replace(
+                '{attribute}',
+                str($attribute)->replace('.', '_')->headline(),
+            );
     }
 }

--- a/app/Rules/ValidAmountForCurrentLocale.php
+++ b/app/Rules/ValidAmountForCurrentLocale.php
@@ -23,7 +23,12 @@ class ValidAmountForCurrentLocale implements DataAwareRule, InvokableRule
         $valueHasPunctuation = Str::of($value)->contains([',', '.']);
 
         try {
-            Money::parse($value, $this->data['speaker_package']['currency'], ! $valueHasPunctuation, App::currentLocale())->getAmount();
+            Money::parse(
+                $value,
+                $this->data['speaker_package']['currency'],
+                ! $valueHasPunctuation,
+                App::currentLocale(),
+            )->getAmount();
         } catch (ParserException $e) {
             $fail($this->formatErrorMessage($attribute));
         }

--- a/database/factories/ConferenceFactory.php
+++ b/database/factories/ConferenceFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Casts\SpeakerPackage;
 use App\Models\Conference;
 use App\Models\ConferenceIssue;
 use App\Models\Submission;
@@ -110,7 +111,7 @@ class ConferenceFactory extends Factory
 
 
         return $this->state([
-            'speaker_package' => $speakerPackage,
+            'speaker_package' => new SpeakerPackage($speakerPackage),
         ]);
     }
 

--- a/resources/views/components/input/group.blade.php
+++ b/resources/views/components/input/group.blade.php
@@ -1,10 +1,16 @@
+@props([
+    'name' => null,
+    'label' => null,
+    'labelClass' => null,
+])
+
 <div
     {{ $attributes->except('v-text')->class('flex items-center') }}
 >
     @if (isset($name) && isset($label))
         <label
             for="{{ $name }}"
-            class="font-extrabold text-indigo-900 mr-2"
+            class="font-extrabold text-indigo-900 mr-2 {{ $labelClass }}"
         >
             {{ $label }}
         </label>

--- a/resources/views/components/input/group.blade.php
+++ b/resources/views/components/input/group.blade.php
@@ -1,8 +1,17 @@
 <div
-    {{ $attributes->except('v-text')->class('flex') }}
+    {{ $attributes->except('v-text')->class('flex items-center') }}
 >
+    @if (isset($name) && isset($label))
+        <label
+            for="{{ $name }}"
+            class="font-extrabold text-indigo-900 mr-2"
+        >
+            {{ $label }}
+        </label>
+    @endif
+
     <span
-        class="p-2 bg-indigo-300 rounded-l-md"
+        class="p-2 border border-form-200 bg-indigo-300 rounded-l-md"
         {{ $attributes->only('v-text') }}
     ></span>
     <div class="flex-1">

--- a/resources/views/components/input/select.blade.php
+++ b/resources/views/components/input/select.blade.php
@@ -1,6 +1,7 @@
 @props([
     'name',
     'label' => null,
+    'labelClass' => null,
     'options' => [],
     'optionText' => '',
     'optionValue' => '',
@@ -21,7 +22,7 @@
     <label
         for="currency"
         class="
-            font-extrabold text-indigo-900
+            font-extrabold text-indigo-900 {{ $labelClass }}
             @unless ($inline) block @endunless
         "
     >

--- a/resources/views/components/input/text.blade.php
+++ b/resources/views/components/input/text.blade.php
@@ -16,10 +16,14 @@
         {{ $label }}
     </label>
 
+    @php
+        $valueName = str($name)->replace('[', '.')->replace(']', '');
+    @endphp
+
     <input
         name="{{ $name }}"
         type="{{ $type }}"
-        value="{{ old($name, $value) }}"
+        value="{{ old((string) $valueName, $value) }}"
         {{ $attributes->except('class') }}
         class="
             bg-white border-form-200 form-input placeholder-form-400 rounded

--- a/resources/views/components/input/text.blade.php
+++ b/resources/views/components/input/text.blade.php
@@ -6,6 +6,7 @@
     'type' => 'text',
     'inline' => false,
     'hideLabel' => false,
+    'roundedClass' => 'rounded',
 ])
 
 <div {{ $attributes->only(['class']) }}>
@@ -26,7 +27,7 @@
         value="{{ old((string) $valueName, $value) }}"
         {{ $attributes->except('class') }}
         class="
-            bg-white border-form-200 form-input placeholder-form-400 rounded
+            bg-white border-form-200 form-input placeholder-form-400 {{ $roundedClass }}
             @unless ($inline) w-full @endunless
             @unless ($hideLabel) mt-1 @endunless
         "

--- a/resources/views/conferences/form.blade.php
+++ b/resources/views/conferences/form.blade.php
@@ -120,7 +120,7 @@
                     >
                         <x-input.text
                             :name='"speaker_package[{$category}]"'
-                            :value="data_get($conference, 'speaker_package.' . $category)"
+                            :value="$conference->speaker_package->toDecimal($category)"
                             :hide-label="true"
                             rounded-class="rounded-r"
                         ></x-input.text>

--- a/resources/views/conferences/form.blade.php
+++ b/resources/views/conferences/form.blade.php
@@ -112,15 +112,15 @@
                     v-model="form.selectedCurrency"
                 ></x-input.select>
 
-                @foreach ($conference::SPEAKER_PACKAGE_ITEMS as $item)
+                @foreach (App\Casts\SpeakerPackage::CATEGORIES as $category)
                     <x-input.group
-                        :name='"speaker_package[{$item}]"'
-                        :label="str($item)->title()"
+                        :name='"speaker_package[{$category}]"'
+                        :label="str($category)->title()"
                         v-text="symbol"
                     >
                         <x-input.text
-                            :name='"speaker_package[{$item}]"'
-                            :value="data_get($conference, 'speaker_package.' . $item)"
+                            :name='"speaker_package[{$category}]"'
+                            :value="data_get($conference, 'speaker_package.' . $category)"
                             :hide-label="true"
                             rounded-class="rounded-r"
                         ></x-input.text>

--- a/resources/views/conferences/form.blade.php
+++ b/resources/views/conferences/form.blade.php
@@ -113,11 +113,16 @@
                 ></x-input.select>
 
                 @foreach ($conference::SPEAKER_PACKAGE_ITEMS as $item)
-                    <x-input.group v-text="symbol">
+                    <x-input.group
+                        :name='"speaker_package[{$item}]"'
+                        :label="str($item)->title()"
+                        v-text="symbol"
+                    >
                         <x-input.text
                             :name='"speaker_package[{$item}]"'
                             :value="data_get($conference, 'speaker_package.' . $item)"
                             :hide-label="true"
+                            rounded-class="rounded-r"
                         ></x-input.text>
                     </x-input.group>
                 @endforeach

--- a/resources/views/conferences/form.blade.php
+++ b/resources/views/conferences/form.blade.php
@@ -115,7 +115,7 @@
                 <x-input.group class="mt-2" v-text="symbol">
                     <x-input.text
                         name="speaker_package[travel]"
-                        value="{{ $package['travel'] ?? 0 }}"
+                        value="{{ old('speaker_package.travel', $package['travel'] ?? 0) }}"
                         :hide-label="true"
                     ></x-input.text>
                 </x-input.group>
@@ -123,7 +123,7 @@
                 <x-input.group class="mt-2" v-text="symbol">
                     <x-input.text
                         name="speaker_package[hotel]"
-                        value="{{ $package['hotel'] ?? 0 }}"
+                        value="{{ old('speaker_package.hotel', $package['hotel'] ?? 0) }}"
                         :hide-label="true"
                     ></x-input.text>
                 </x-input.group>
@@ -131,7 +131,7 @@
                 <x-input.group class="mt-2" v-text="symbol">
                     <x-input.text
                         name="speaker_package[food]"
-                        value="{{ $package['food'] ?? 0 }}"
+                        value="{{ old('speaker_package.food', $package['food'] ?? 0) }}"
                         :hide-label="true"
                     ></x-input.text>
                 </x-input.group>

--- a/resources/views/conferences/form.blade.php
+++ b/resources/views/conferences/form.blade.php
@@ -104,6 +104,7 @@
                 <x-input.select
                     name="speaker_package[currency]"
                     label="Currency"
+                    label-class="w-20 text-right"
                     :options="$currencies"
                     option-text="code"
                     option-value="code"
@@ -116,6 +117,7 @@
                     <x-input.group
                         :name='"speaker_package[{$category}]"'
                         :label="str($category)->title()"
+                        label-class="w-20 text-right"
                         v-text="symbol"
                     >
                         <x-input.text

--- a/resources/views/conferences/form.blade.php
+++ b/resources/views/conferences/form.blade.php
@@ -100,7 +100,7 @@
         initial-currency="{{ $conference->speaker_package->currency ?? 'USD' }}"
     >
         <template #default="{symbol, form}">
-            <div class="w-full md:w-1/3">
+            <div class="w-full md:w-1/3 space-y-4">
                 <x-input.select
                     name="speaker_package[currency]"
                     label="Currency"
@@ -112,29 +112,15 @@
                     v-model="form.selectedCurrency"
                 ></x-input.select>
 
-                <x-input.group class="mt-2" v-text="symbol">
-                    <x-input.text
-                        name="speaker_package[travel]"
-                        value="{{ old('speaker_package.travel', $package['travel'] ?? 0) }}"
-                        :hide-label="true"
-                    ></x-input.text>
-                </x-input.group>
-
-                <x-input.group class="mt-2" v-text="symbol">
-                    <x-input.text
-                        name="speaker_package[hotel]"
-                        value="{{ old('speaker_package.hotel', $package['hotel'] ?? 0) }}"
-                        :hide-label="true"
-                    ></x-input.text>
-                </x-input.group>
-
-                <x-input.group class="mt-2" v-text="symbol">
-                    <x-input.text
-                        name="speaker_package[food]"
-                        value="{{ old('speaker_package.food', $package['food'] ?? 0) }}"
-                        :hide-label="true"
-                    ></x-input.text>
-                </x-input.group>
+                @foreach ($conference::SPEAKER_PACKAGE_ITEMS as $item)
+                    <x-input.group v-text="symbol">
+                        <x-input.text
+                            :name='"speaker_package[{$item}]"'
+                            :value="data_get($conference, 'speaker_package.' . $item)"
+                            :hide-label="true"
+                        ></x-input.text>
+                    </x-input.group>
+                @endforeach
             </div>
         </template>
     </currency-selection>

--- a/tests/Feature/SpeakerPackageTest.php
+++ b/tests/Feature/SpeakerPackageTest.php
@@ -23,13 +23,15 @@ class SpeakerPackageTest extends TestCase
             'hotel' => 10,
         ];
 
-        $this->actingAs($user)
+        $this->followingRedirects()
+            ->actingAs($user)
             ->post('conferences', [
                 'title' => 'Das Conf',
                 'description' => 'A very good conference about things',
                 'url' => 'http://dasconf.org',
                 'speaker_package' => $speakerPackage,
-            ]);
+            ])
+            ->assertSuccessful();
 
         $this->assertDatabaseHasSpeakerPackage($speakerPackage);
     }

--- a/tests/Feature/SpeakerPackageTest.php
+++ b/tests/Feature/SpeakerPackageTest.php
@@ -95,6 +95,26 @@ class SpeakerPackageTest extends TestCase
     }
 
     /** @test */
+    public function speaker_package_can_be_removed()
+    {
+        $user = User::factory()->create();
+        $conference = Conference::factory()
+            ->author($user)
+            ->withSpeakerPackage()
+            ->create();
+
+        $this->actingAs($user)
+            ->put("/conferences/{$conference->id}", array_merge($conference->toArray(), [
+                'speaker_package' => [],
+            ]));
+
+        tap($conference->fresh(), function ($conference) {
+            $this->assertNull($conference->speaker_package->currency);
+            $this->assertEquals(0, $conference->speaker_package->count());
+        });
+    }
+
+    /** @test */
     public function decimal_values_are_stored_as_whole_numbers()
     {
         $user = User::factory()->create();

--- a/tests/Feature/SpeakerPackageTest.php
+++ b/tests/Feature/SpeakerPackageTest.php
@@ -31,7 +31,11 @@ class SpeakerPackageTest extends TestCase
             ])
             ->assertSuccessful();
 
-        $this->assertDatabaseHasSpeakerPackage($speakerPackage);
+        $this->assertDatabaseHasSpeakerPackage($speakerPackage, [
+            'title' => 'Das Conf',
+            'description' => 'A very good conference about things',
+            'url' => 'http://dasconf.org',
+        ]);
     }
 
     /** @test */
@@ -59,7 +63,10 @@ class SpeakerPackageTest extends TestCase
                 'speaker_package' => $speakerPackage,
             ]));
 
-        $this->assertDatabaseHasSpeakerPackage($speakerPackage);
+        $this->assertDatabaseHasSpeakerPackage($speakerPackage, [
+            'title' => 'My updated conference',
+            'description' => 'Conference has been changed a bit.',
+        ]);
     }
 
     /** @test */
@@ -219,12 +226,12 @@ class SpeakerPackageTest extends TestCase
         ]);
     }
 
-    private function assertDatabaseHasSpeakerPackage($package)
+    private function assertDatabaseHasSpeakerPackage($package, $data = [])
     {
-        $this->assertDatabaseHas(Conference::class, [
+        $this->assertDatabaseHas(Conference::class, array_merge($data, [
             'speaker_package' => json_encode(
                 (new SpeakerPackage($package))->toDatabase()
             ),
-        ]);
+        ]));
     }
 }

--- a/tests/Feature/SpeakerPackageTest.php
+++ b/tests/Feature/SpeakerPackageTest.php
@@ -5,9 +5,7 @@ namespace Tests\Feature;
 use App\Casts\SpeakerPackage;
 use App\Models\Conference;
 use App\Models\User;
-use Cknow\Money\Money;
 use Illuminate\Support\Facades\App;
-use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class SpeakerPackageTest extends TestCase
@@ -223,19 +221,10 @@ class SpeakerPackageTest extends TestCase
 
     private function assertDatabaseHasSpeakerPackage($package)
     {
-        $speakerPackage = [
-            'currency' => $package['currency'],
-        ];
-
-        // Since users have the ability to enter punctuation or not, then we want to use the appropriate parser
-        foreach (SpeakerPackage::CATEGORIES as $item) {
-            $itemHasPunctuation = Str::of($package[$item])->contains([',', '.']);
-
-            $speakerPackage[$item] = Money::parse($package[$item], $package['currency'], ! $itemHasPunctuation, App::currentLocale())->getAmount();
-        }
-
         $this->assertDatabaseHas(Conference::class, [
-            'speaker_package' => json_encode($speakerPackage),
+            'speaker_package' => json_encode(
+                (new SpeakerPackage($package))->toDatabase()
+            ),
         ]);
     }
 }

--- a/tests/Feature/SpeakerPackageTest.php
+++ b/tests/Feature/SpeakerPackageTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Casts\SpeakerPackage;
 use App\Models\Conference;
 use App\Models\User;
 use Cknow\Money\Money;
@@ -225,7 +226,7 @@ class SpeakerPackageTest extends TestCase
         ];
 
         // Since users have the ability to enter punctuation or not, then we want to use the appropriate parser
-        foreach (['travel', 'food', 'hotel'] as $item) {
+        foreach (SpeakerPackage::CATEGORIES as $item) {
             $itemHasPunctuation = Str::of($package[$item])->contains([',', '.']);
 
             $speakerPackage[$item] = Money::parse($package[$item], $package['currency'], ! $itemHasPunctuation, App::currentLocale())->getAmount();


### PR DESCRIPTION
This PR makes the following visual updates to speaker packages:
- Failed category amounts will now read `Speaker package {category} amount is invalid. Please update formatting and try again.`
- Previous request speaker package data is populated on failed conference validation
- Amounts default to null instead of 0
- `Food`, `Hotel`, and `Travel` labels have been added to the amount fields

<img width="355" alt="image" src="https://user-images.githubusercontent.com/1121383/229763212-8e477041-5702-4093-81c1-91155213456c.png">

In addition, the `SpeakerPackage` custom cast object has been updated to encapsulate speaker package concerns that were leaked to the controller and form request object.