### PR TITLE
Conference scout search update

### DIFF
--- a/app/Http/Livewire/ConferenceList.php
+++ b/app/Http/Livewire/ConferenceList.php
@@ -55,7 +55,7 @@ class ConferenceList extends Component
 
     public function getConferencesProperty()
     {
-        return Conference::search($this->search)->query(function ($query) {
+        return Conference::searchQuery($this->search, function ($query) {
             $query->approved()
                 ->filterByAll($this->filter, $this->date, $this->dateColumn())
                 ->filterByFuture($this->filter, $this->dateColumn())

--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -73,6 +73,15 @@ class Conference extends UuidBase
         'has_cfp' => true,
     ];
 
+    public static function searchQuery($search, $query)
+    {
+        if (! $search) {
+            return static::where($query);
+        }
+
+        return static::search($search)->query($query);
+    }
+
     public static function boot()
     {
         parent::boot();

--- a/tests/Feature/ConferenceTest.php
+++ b/tests/Feature/ConferenceTest.php
@@ -588,7 +588,10 @@ class ConferenceTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $conference = Conference::factory()->approved()->create();
+        $conference = Conference::factory()
+            ->dates(now())
+            ->approved()
+            ->create();
         $user->conferences()
             ->save($conference);
 


### PR DESCRIPTION
This PR updates the conference search page to only search Algolia when a search term is given.