### PR TITLE
Hide past conferences when filtering by open CFP

### DIFF
--- a/app/Http/Livewire/ConferenceList.php
+++ b/app/Http/Livewire/ConferenceList.php
@@ -226,7 +226,7 @@ class ConferenceList extends Component
                 return function ($filter) {
                     return $this->when(
                         $filter === 'open_cfp',
-                        fn ($q) => $q->whereCfpIsOpen(),
+                        fn ($q) => $q->whereCfpIsOpen()->future(),
                     );
                 };
             }

--- a/tests/Feature/ConferenceTest.php
+++ b/tests/Feature/ConferenceTest.php
@@ -751,6 +751,25 @@ class ConferenceTest extends TestCase
     }
 
     /** @test */
+    public function filtering_by_open_cfp_hides_conferences_without_event_dates()
+    {
+        $user = User::factory()->create();
+
+        $conference = Conference::factory()->approved()->create([
+            'has_cfp' => true,
+            'cfp_starts_at' => now()->subDay(),
+            'cfp_ends_at' => now()->addDay(),
+            'starts_at' => now()->subDay(),
+            'ends_at' => now()->subDay(),
+        ]);
+        $user->conferences()->save($conference);
+
+        $this->actingAs($user)
+            ->get('conferences?filter=open_cfp')
+            ->assertDontSee($conference->title);
+    }
+
+    /** @test */
     public function filtering_by_future_cfp_hides_non_cfp_conferences()
     {
         $user = User::factory()->create();


### PR DESCRIPTION
This PR modifies the `Open CFP` conference list filter to limit the results to future conferences.  This will prevent past conferences with CFP end dates far into the future from displaying when filtering by open CFP.