### PR TITLE
Constrain conference search to future conferences

### DIFF
--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -263,6 +263,11 @@ class Conference extends UuidBase
         });
     }
 
+    public function shouldBeSearchable(): bool
+    {
+        return $this->starts_at > Carbon::now();
+    }
+
     /**
      * Whether CFP is currently open
      *


### PR DESCRIPTION
This PR constrains the conference search index to conferences taking place in the future.