### PR TITLE
Add missing ID to searchable array

### DIFF
--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -314,6 +314,7 @@ class Conference extends UuidBase
     public function toSearchableArray()
     {
         return [
+            'id' => $this->id,
             'title' => $this->title,
             'location' => $this->location,
         ];


### PR DESCRIPTION
This PR adds `id` to the `Conference` searchable array in order to prevent errors when making conferences searchable.