### PR TITLE
Fix conference search error

### DIFF
--- a/app/Models/UuidBase.php
+++ b/app/Models/UuidBase.php
@@ -12,6 +12,8 @@ class UuidBase extends Eloquent
      */
     public $incrementing = false;
 
+    protected $keyType = 'string';
+
     /**
      * Boot function from laravel.
      */

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -35,7 +35,7 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
-        <env name="SCOUT_DRIVER" value="database"/>
+        <env name="SCOUT_DRIVER" value="collection"/>
         <env name="CAPTCHA_PUBLIC" value="6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI"/>
         <env name="CAPTCHA_PRIVATE" value="6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe"/>
     </php>

--- a/tests/Feature/ConferenceTest.php
+++ b/tests/Feature/ConferenceTest.php
@@ -1215,4 +1215,16 @@ class ConferenceTest extends TestCase
         $this->assertFalse($conferenceA->isRejected());
         $this->assertTrue($conferenceB->isRejected());
     }
+
+    /** @test */
+    public function searching_conferences_by_name(): void
+    {
+        $conferenceA = Conference::factory()->create(['location' => 'Boston, MA']);
+        $conferenceB = Conference::factory()->create(['location' => 'New York, NY']);
+
+        $results = Conference::searchQuery('boston', fn ($query) => $query)->get();
+
+        $this->assertContains($conferenceA->id, $results->pluck('id'));
+        $this->assertNotContains($conferenceB->id, $results->pluck('id'));
+    }
 }


### PR DESCRIPTION
This PR fixes an error that occurring when the `Laravel\Scout\Jobs\MakeSearchable` job is queued for a conference.  These jobs are failing with a `MaxAttemptsExceededException` being thrown.  These jobs are inserted in the `failed_jobs` table with the correct conference ID but the underlying query is recorded in Bugsnag as follows:

```sql
select * from `conferences` where `conferences`.`id` in (0)
```

[This Scout issue](https://github.com/laravel/scout/issues/741) led me to the `Laravel\Scout\Searchable::queryScoutModelsByIds` method, which determine's the model's key via the `Model::getKeyType` method.  When the key type is `int`, which is the Eloquent default, the query is built with `whereIntegerInRaw`, which cast's the key as an `int`.

Since the `Conference` model uses a UUID primary key, the `queryScoutModelsByIds` method was casting the UUID value as an int, which resulted in the SQL query above.

Adding `protected $keyType = 'string';` to the `App\Models\UuidBase` class results in the `queryScoutModelsByIds` method using a `whereIn` query instead of the `whereIntegerInRaw`, which fixes this issue.