### PR TITLE
Exclude rejected conferences from search index

### DIFF
--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -265,7 +265,7 @@ class Conference extends UuidBase
 
     public function shouldBeSearchable(): bool
     {
-        return $this->starts_at > Carbon::now();
+        return $this->starts_at > Carbon::now() && ! $this->isRejected();
     }
 
     /**

--- a/tests/Feature/ConferenceTest.php
+++ b/tests/Feature/ConferenceTest.php
@@ -1227,4 +1227,24 @@ class ConferenceTest extends TestCase
         $this->assertContains($conferenceA->id, $results->pluck('id'));
         $this->assertNotContains($conferenceB->id, $results->pluck('id'));
     }
+
+    /** @test */
+    public function past_conferences_are_not_searchable(): void
+    {
+        $conferenceA = Conference::factory()->dates(now()->subDay())->create();
+        $conferenceB = Conference::factory()->dates(now()->addDay())->create();
+
+        $this->assertFalse($conferenceA->shouldBeSearchable());
+        $this->assertTrue($conferenceB->shouldBeSearchable());
+    }
+
+    /** @test */
+    public function rejected_conferences_are_not_searchable(): void
+    {
+        $conferenceA = Conference::factory()->create(['rejected_at' => now()]);
+        $conferenceB = Conference::factory()->create(['rejected_at' => null]);
+
+        $this->assertFalse($conferenceA->shouldBeSearchable());
+        $this->assertTrue($conferenceB->shouldBeSearchable());
+    }
 }


### PR DESCRIPTION
This PR updates the `Conference::shouldBeSearchable` method to exclude rejected conferences from being included in the search index.