### PR TITLE
Prevent re-indexing conferences without updates

### DIFF
--- a/app/CallingAllPapers/ConferenceImporter.php
+++ b/app/CallingAllPapers/ConferenceImporter.php
@@ -79,7 +79,9 @@ class ConferenceImporter
             $conference->rejected_at = now();
         }
 
-        $conference->save();
+        if ($conference->isDirty()) {
+            $conference->save();
+        }
 
         return $conference;
     }


### PR DESCRIPTION
This PR prevents unnecessary conference re-indexing by only saving in the conference importer when there are updates to the conference.