### PR TITLE
Prevent re-importing rejected conferences

### DIFF
--- a/app/CallingAllPapers/ConferenceImporter.php
+++ b/app/CallingAllPapers/ConferenceImporter.php
@@ -68,7 +68,9 @@ class ConferenceImporter
             ],
         ]);
 
-        $conference = Conference::firstOrNew(['calling_all_papers_id' => $event->id]);
+        $conference = Conference::query()
+            ->withoutGlobalScope('notRejected')
+            ->firstOrNew(['calling_all_papers_id' => $event->id]);
         $this->updateConferenceFromCallingAllPapersEvent($conference, $event);
 
         if (! $conference->latitude && ! $conference->longitude && $conference->location) {

--- a/tests/Feature/CallingAllPapersConferenceImporterTest.php
+++ b/tests/Feature/CallingAllPapersConferenceImporterTest.php
@@ -383,6 +383,29 @@ class CallingAllPapersConferenceImporterTest extends TestCase
     }
 
     /** @test */
+    public function rejected_conferences_cannot_be_reimported()
+    {
+        $this->mockClient();
+
+        $conference = Conference::factory()->rejected()->create([
+            'calling_all_papers_id' => 'fake-cfp-id',
+        ]);
+
+        $importer = new ConferenceImporter(1);
+        $event = $this->eventStub;
+        $event->id = 'fake-cfp-id';
+        $event->dateCfpStart = '2014-06-01T00:00:00-04:00';
+        $event->dateCfpEnd = '2017-06-01T00:00:00-04:00';
+        $importer->import($event);
+
+        $conferenceCount = Conference::withoutGlobalScope('notRejected')
+            ->where('calling_all_papers_id', 'fake-cfp-id')
+            ->count();
+
+        $this->assertEquals(1, $conferenceCount);
+    }
+
+    /** @test */
     public function conferences_with_null_cfp_start_are_valid_with_cfp_end_less_than_2_years_in_future()
     {
         $this->mockClient();


### PR DESCRIPTION
This PR prevents re-importing rejected conferences by updating the conference importer to query conferences without the `notRejected` global scope to ensure previously imported conferences will be matched with the `calling_all_papers_id` value.