### PR TITLE
Add nofollow rel to conference links

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -6,3 +6,16 @@ if (! function_exists('markdown')) {
         return '<div class="markdown">' . (new Parsedown())->text($text) . '</div>';
     }
 }
+
+if (! function_exists('append_url')) {
+    function append_url($url, $params = null)
+    {
+        $char = Str::contains($url, '?') ? '&' : '?';
+
+        if (! is_array($params)) {
+            return false;
+        }
+
+        return $url . $char . http_build_query($params);
+    }
+}

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -6,16 +6,3 @@ if (! function_exists('markdown')) {
         return '<div class="markdown">' . (new Parsedown())->text($text) . '</div>';
     }
 }
-
-if (! function_exists('append_url')) {
-    function append_url($url, $params = null)
-    {
-        $char = Str::contains($url, '?') ? '&' : '?';
-
-        if (! is_array($params)) {
-            return false;
-        }
-
-        return $url . $char . http_build_query($params);
-    }
-}

--- a/resources/views/components/panel/conference.blade.php
+++ b/resources/views/components/panel/conference.blade.php
@@ -31,7 +31,8 @@
 
         <div class="mt-4 text-gray-500">URL:</div>
         <a
-            href="{{ append_url($conference->url, ['rel' => 'nofollow']) }}"
+            href="{{ $conference->url }}"
+            rel="nofollow"
             class="hover:text-indigo-500"
         >
             {{ $conference->url }}
@@ -40,7 +41,8 @@
         @if ($conference->has_cfp && $conference->cfp_url)
             <div class="mt-4 text-gray-500">URL for CFP page:</div>
             <a
-                href="{{ append_url($conference->cfp_url, ['rel' => 'nofollow']) }}"
+                href="{{ $conference->cfp_url }}"
+                rel="nofollow"
                 class="hover:text-indigo-500"
             >
                 {{ $conference->cfp_url }}

--- a/resources/views/components/panel/conference.blade.php
+++ b/resources/views/components/panel/conference.blade.php
@@ -31,7 +31,7 @@
 
         <div class="mt-4 text-gray-500">URL:</div>
         <a
-            href="{{ $conference->url }}"
+            href="{{ append_url($conference->url, ['rel' => 'nofollow']) }}"
             class="hover:text-indigo-500"
         >
             {{ $conference->url }}
@@ -40,7 +40,7 @@
         @if ($conference->has_cfp && $conference->cfp_url)
             <div class="mt-4 text-gray-500">URL for CFP page:</div>
             <a
-                href="{{ $conference->cfp_url }}"
+                href="{{ append_url($conference->cfp_url, ['rel' => 'nofollow']) }}"
                 class="hover:text-indigo-500"
             >
                 {{ $conference->cfp_url }}

--- a/tests/Integration/GeocoderTest.php
+++ b/tests/Integration/GeocoderTest.php
@@ -16,8 +16,8 @@ class GeocoderTest extends TestCase
 
         $coordinates = $geocoder->geocode('1600 Pennsylvania Ave Washington, DC');
 
-        $this->assertEquals('38.8976633', $coordinates->getLatitude());
-        $this->assertEquals('-77.0365739', $coordinates->getLongitude());
+        $this->assertEquals('38.8976801', $coordinates->getLatitude());
+        $this->assertEquals('-77.0363304', $coordinates->getLongitude());
     }
 
     /** @test */


### PR DESCRIPTION
This PR adds `rel=nofollow` to conference URLs and CFP URLs on the `conferences.show` page.