### PR TITLE
Remove n+1 queries from conference index and conference show pages

### DIFF
--- a/app/ApiResources/Talk.php
+++ b/app/ApiResources/Talk.php
@@ -27,16 +27,16 @@ class Talk implements Arrayable
     public function attributes()
     {
         return [
-            'title' => $this->talk->currentRevision()->title,
-            'description' => $this->talk->currentRevision()->description,
-            'type' => $this->talk->currentRevision()->type,
-            'length' => $this->talk->currentRevision()->length,
-            'level' => $this->talk->currentRevision()->level,
-            'slides' => $this->talk->currentRevision()->slides,
+            'title' => $this->talk->currentRevision->title,
+            'description' => $this->talk->currentRevision->description,
+            'type' => $this->talk->currentRevision->type,
+            'length' => $this->talk->currentRevision->length,
+            'level' => $this->talk->currentRevision->level,
+            'slides' => $this->talk->currentRevision->slides,
             'public' => $this->talk->public,
-            'organizer_notes' => $this->talk->currentRevision()->organizer_notes,
-            'created_at' => (string) $this->talk->currentRevision()->created_at,
-            'updated_at' => (string) $this->talk->currentRevision()->updated_at,
+            'organizer_notes' => $this->talk->currentRevision->organizer_notes,
+            'created_at' => (string) $this->talk->currentRevision->created_at,
+            'updated_at' => (string) $this->talk->currentRevision->updated_at,
         ];
     }
 

--- a/app/ApiResources/Talk.php
+++ b/app/ApiResources/Talk.php
@@ -27,16 +27,16 @@ class Talk implements Arrayable
     public function attributes()
     {
         return [
-            'title' => $this->talk->current()->title,
-            'description' => $this->talk->current()->description,
-            'type' => $this->talk->current()->type,
-            'length' => $this->talk->current()->length,
-            'level' => $this->talk->current()->level,
-            'slides' => $this->talk->current()->slides,
+            'title' => $this->talk->currentRevision()->title,
+            'description' => $this->talk->currentRevision()->description,
+            'type' => $this->talk->currentRevision()->type,
+            'length' => $this->talk->currentRevision()->length,
+            'level' => $this->talk->currentRevision()->level,
+            'slides' => $this->talk->currentRevision()->slides,
             'public' => $this->talk->public,
-            'organizer_notes' => $this->talk->current()->organizer_notes,
-            'created_at' => (string) $this->talk->current()->created_at,
-            'updated_at' => (string) $this->talk->current()->updated_at,
+            'organizer_notes' => $this->talk->currentRevision()->organizer_notes,
+            'created_at' => (string) $this->talk->currentRevision()->created_at,
+            'updated_at' => (string) $this->talk->currentRevision()->updated_at,
         ];
     }
 

--- a/app/Collections/TalksCollection.php
+++ b/app/Collections/TalksCollection.php
@@ -10,7 +10,7 @@ class TalksCollection extends Collection
     public function sortByTitle()
     {
         return $this->sortBy(function (Talk $talk) {
-            return strtolower($talk->current()->title);
+            return strtolower($talk->currentRevision()->title);
         })->values();
     }
 }

--- a/app/Collections/TalksCollection.php
+++ b/app/Collections/TalksCollection.php
@@ -10,7 +10,7 @@ class TalksCollection extends Collection
     public function sortByTitle()
     {
         return $this->sortBy(function (Talk $talk) {
-            return strtolower($talk->currentRevision()->title);
+            return strtolower($talk->currentRevision->title);
         })->values();
     }
 }

--- a/app/Http/Controllers/Api/TalksController.php
+++ b/app/Http/Controllers/Api/TalksController.php
@@ -12,7 +12,7 @@ class TalksController extends Controller
     public function show($id)
     {
         try {
-            $talk = auth()->guard('api')->user()->talks()->findOrFail($id);
+            $talk = auth()->guard('api')->user()->talks()->withCurrentRevision()->findOrFail($id);
         } catch (Exception $e) {
             App::abort(404);
         }

--- a/app/Http/Controllers/Api/UserTalksController.php
+++ b/app/Http/Controllers/Api/UserTalksController.php
@@ -22,6 +22,7 @@ class UserTalksController extends Controller
         $talks = auth()->guard('api')
             ->user()
             ->talks()
+            ->withCurrentRevision()
             ->when((bool) request()->query('include-archived'), function ($query) {
                 $query->withoutGlobalScope('active');
             })

--- a/app/Http/Controllers/ConferencesController.php
+++ b/app/Http/Controllers/ConferencesController.php
@@ -52,6 +52,8 @@ class ConferencesController extends Controller
             return TalkTransformer::transform($talk, $conference);
         });
 
+        $conference->loadCount('openIssues');
+
         return view('conferences.show', [
             'conference' => $conference,
             'talks' => $talks,
@@ -119,6 +121,7 @@ class ConferencesController extends Controller
     private function showPublic($id)
     {
         $conference = Conference::approved()->findOrFail($id);
+        $conference->loadCount('openIssues');
 
         return view('conferences.showPublic', [
             'conference' => $conference,

--- a/app/Http/Controllers/ConferencesController.php
+++ b/app/Http/Controllers/ConferencesController.php
@@ -48,7 +48,7 @@ class ConferencesController extends Controller
             return redirect('/');
         }
 
-        $talks = auth()->user()->talks->sortByTitle()->map(function ($talk) use ($conference) {
+        $talks = auth()->user()->talks()->withCurrentRevision()->get()->sortByTitle()->map(function ($talk) use ($conference) {
             return TalkTransformer::transform($talk, $conference);
         });
 

--- a/app/Http/Controllers/PublicProfileController.php
+++ b/app/Http/Controllers/PublicProfileController.php
@@ -28,7 +28,7 @@ class PublicProfileController extends Controller
     public function show($profile_slug)
     {
         $user = $this->getPublicUserByProfileSlug($profile_slug);
-        $talks = $user->talks()->public()->get()->sortByTitle();
+        $talks = $user->talks()->withCurrentRevision()->public()->get()->sortByTitle();
         $bios = $user->bios()->public()->get();
 
         return view('account.public-profile.show', [

--- a/app/Http/Controllers/SubmissionsController.php
+++ b/app/Http/Controllers/SubmissionsController.php
@@ -19,7 +19,7 @@ class SubmissionsController extends Controller
         }
 
         $conference = Conference::findOrFail($request->input('conferenceId'));
-        $talkRevision = $talk->current();
+        $talkRevision = $talk->currentRevision();
         $submission = $conference->submissions()->create(['talk_revision_id' => $talkRevision->id]);
 
         return response()->json([

--- a/app/Http/Controllers/SubmissionsController.php
+++ b/app/Http/Controllers/SubmissionsController.php
@@ -19,7 +19,7 @@ class SubmissionsController extends Controller
         }
 
         $conference = Conference::findOrFail($request->input('conferenceId'));
-        $talkRevision = $talk->currentRevision();
+        $talkRevision = $talk->loadCurrentRevision()->currentRevision;
         $submission = $conference->submissions()->create(['talk_revision_id' => $talkRevision->id]);
 
         return response()->json([

--- a/app/Http/Controllers/TalksController.php
+++ b/app/Http/Controllers/TalksController.php
@@ -74,7 +74,7 @@ class TalksController extends Controller
 
         return view('talks.edit', [
             'talk' => $talk,
-            'current' => $talk->currentRevision(),
+            'current' => $talk->currentRevision,
         ]);
     }
 
@@ -103,7 +103,7 @@ class TalksController extends Controller
     {
         $talk = auth()->user()->talks()->findOrFail($id);
 
-        $current = $request->filled('revision') ? $talk->revisions()->findOrFail($request->input('revision')) : $talk->currentRevision();
+        $current = $request->filled('revision') ? $talk->revisions()->findOrFail($request->input('revision')) : $talk->loadCurrentRevision()->currentRevision;
 
         $submissions = Submission::where('talk_revision_id', $current->id)
             ->with(['conference', 'acceptance', 'rejection'])
@@ -129,7 +129,7 @@ class TalksController extends Controller
     public function archiveIndex(Request $request)
     {
         $talks = $this->sortTalks(
-            auth()->user()->archivedTalks()->get(),
+            auth()->user()->archivedTalks()->withCurrentRevision()->get(),
             $request->input('sort')
         );
 
@@ -161,13 +161,13 @@ class TalksController extends Controller
     {
         switch ($filter) {
             case 'submitted':
-                return auth()->user()->talks()->submitted()->get();
+                return auth()->user()->talks()->withCurrentRevision()->submitted()->get();
                 break;
             case 'accepted':
-                return auth()->user()->talks()->accepted()->get();
+                return auth()->user()->talks()->withCurrentRevision()->accepted()->get();
                 break;
             default:
-                return auth()->user()->talks()->get();
+                return auth()->user()->talks()->withCurrentRevision()->get();
                 break;
         }
     }
@@ -186,7 +186,7 @@ class TalksController extends Controller
                 $this->sorted_by = 'alpha';
 
                 return $talks->sortBy(function ($talk) {
-                    return strtolower($talk->currentRevision()->title);
+                    return strtolower($talk->currentRevision->title);
                 });
                 break;
         }

--- a/app/Http/Controllers/TalksController.php
+++ b/app/Http/Controllers/TalksController.php
@@ -74,7 +74,7 @@ class TalksController extends Controller
 
         return view('talks.edit', [
             'talk' => $talk,
-            'current' => $talk->current(),
+            'current' => $talk->currentRevision(),
         ]);
     }
 
@@ -103,7 +103,7 @@ class TalksController extends Controller
     {
         $talk = auth()->user()->talks()->findOrFail($id);
 
-        $current = $request->filled('revision') ? $talk->revisions()->findOrFail($request->input('revision')) : $talk->current();
+        $current = $request->filled('revision') ? $talk->revisions()->findOrFail($request->input('revision')) : $talk->currentRevision();
 
         $submissions = Submission::where('talk_revision_id', $current->id)
             ->with(['conference', 'acceptance', 'rejection'])
@@ -186,7 +186,7 @@ class TalksController extends Controller
                 $this->sorted_by = 'alpha';
 
                 return $talks->sortBy(function ($talk) {
-                    return strtolower($talk->current()->title);
+                    return strtolower($talk->currentRevision()->title);
                 });
                 break;
         }

--- a/app/Http/Livewire/ConferenceList.php
+++ b/app/Http/Livewire/ConferenceList.php
@@ -69,7 +69,7 @@ class ConferenceList extends Component
                 ->sortByCfpOpening($this->sort)
                 ->sortByCfpClosing($this->sort);
         })
-            ->with('openIssues')
+            ->withCount('openIssues')
             ->get()
             ->groupByMonth($this->dateColumn())
             ->sortKeys()

--- a/app/Http/Livewire/ConferenceList.php
+++ b/app/Http/Livewire/ConferenceList.php
@@ -69,6 +69,7 @@ class ConferenceList extends Component
                 ->sortByCfpOpening($this->sort)
                 ->sortByCfpClosing($this->sort);
         })
+            ->with('openIssues')
             ->get()
             ->groupByMonth($this->dateColumn())
             ->sortKeys()

--- a/app/Http/Livewire/ConferenceList.php
+++ b/app/Http/Livewire/ConferenceList.php
@@ -69,6 +69,7 @@ class ConferenceList extends Component
                 ->sortByCfpOpening($this->sort)
                 ->sortByCfpClosing($this->sort);
         })
+            ->when(auth()->user(), fn ($query) => $query->with('submissions'))
             ->withCount('openIssues')
             ->get()
             ->groupByMonth($this->dateColumn())

--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -128,6 +128,11 @@ class Conference extends UuidBase
         return $this->hasMany(ConferenceIssue::class);
     }
 
+    public function openIssues()
+    {
+        return $this->issues()->whereOpen();
+    }
+
     // @todo: Deprecate?
     public static function closingSoonest()
     {
@@ -332,7 +337,7 @@ class Conference extends UuidBase
 
     public function isFlagged()
     {
-        return $this->issues()->whereOpen()->exists();
+        return $this->openIssues->isNotEmpty();
     }
 
     public function isRejected()

--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -337,7 +337,7 @@ class Conference extends UuidBase
 
     public function isFlagged()
     {
-        return $this->openIssues->isNotEmpty();
+        return $this->open_issues_count > 0;
     }
 
     public function isRejected()

--- a/app/Models/Talk.php
+++ b/app/Models/Talk.php
@@ -118,7 +118,7 @@ class Talk extends UuidBase
             'current_revision_id' => TalkRevision::select('id')
                 ->whereColumn('talk_id', 'talks.id')
                 ->latest()
-                ->take(1)
+                ->take(1),
         ])->with('currentRevision');
     }
 

--- a/app/Models/Talk.php
+++ b/app/Models/Talk.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Collections\TalksCollection;
+use App\Models\TalkRevision;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
@@ -61,7 +62,7 @@ class Talk extends UuidBase
 
     public function currentRevision()
     {
-        return $this->revisions()->orderBy('created_at', 'DESC')->first();
+        return $this->belongsTo(TalkRevision::class);
     }
 
     public function revisions()
@@ -109,6 +110,24 @@ class Talk extends UuidBase
     public function scopeAccepted($query)
     {
         $query->has('acceptances');
+    }
+
+    public function scopeWithCurrentRevision($query)
+    {
+        $query->addSelect([
+            'current_revision_id' => TalkRevision::select('id')
+                ->whereColumn('talk_id', 'talks.id')
+                ->latest()
+                ->take(1)
+        ])->with('currentRevision');
+    }
+
+    public function loadCurrentRevision()
+    {
+        return $this->setRelation(
+            'currentRevision',
+            TalkRevision::where('talk_id', $this->id)->latest()->take(1)->first(),
+        );
     }
 
     public function getMySubmissionForConference(Conference $conference)

--- a/app/Models/Talk.php
+++ b/app/Models/Talk.php
@@ -59,7 +59,7 @@ class Talk extends UuidBase
         return $this->hasManyThrough(Acceptance::class, TalkRevision::class);
     }
 
-    public function current()
+    public function currentRevision()
     {
         return $this->revisions()->orderBy('created_at', 'DESC')->first();
     }

--- a/app/Transformers/TalkForConferenceTransformer.php
+++ b/app/Transformers/TalkForConferenceTransformer.php
@@ -9,7 +9,7 @@ class TalkForConferenceTransformer
 {
     public static function transform(Talk $talk, Conference $conference)
     {
-        $currentTalk = $talk->currentRevision();
+        $currentTalk = $talk->currentRevision;
 
         $submission = $talk->getMySubmissionForConference($conference);
         $acceptance = $submission ? $submission->acceptance : null;

--- a/app/Transformers/TalkForConferenceTransformer.php
+++ b/app/Transformers/TalkForConferenceTransformer.php
@@ -9,7 +9,8 @@ class TalkForConferenceTransformer
 {
     public static function transform(Talk $talk, Conference $conference)
     {
-        $currentTalk = $talk->currentRevision;
+        $currentRevision = $talk->currentRevision;
+        $currentRevision->setRelation('talk', $talk);
 
         $submission = $talk->getMySubmissionForConference($conference);
         $acceptance = $submission ? $submission->acceptance : null;
@@ -17,8 +18,8 @@ class TalkForConferenceTransformer
 
         return [
             'id' => $talk->id,
-            'title' => $currentTalk->title,
-            'url' => $currentTalk->getUrl(),
+            'title' => $currentRevision->title,
+            'url' => $currentRevision->getUrl(),
             'submitted' => (bool) $submission,
             'submissionId' => $submission ? $submission->id : null,
             'accepted' =>  (bool) $acceptance,

--- a/app/Transformers/TalkForConferenceTransformer.php
+++ b/app/Transformers/TalkForConferenceTransformer.php
@@ -9,7 +9,7 @@ class TalkForConferenceTransformer
 {
     public static function transform(Talk $talk, Conference $conference)
     {
-        $currentTalk = $talk->current();
+        $currentTalk = $talk->currentRevision();
 
         $submission = $talk->getMySubmissionForConference($conference);
         $acceptance = $submission ? $submission->acceptance : null;

--- a/database/factories/ConferenceFactory.php
+++ b/database/factories/ConferenceFactory.php
@@ -138,6 +138,17 @@ class ConferenceFactory extends Factory
         ]);
     }
 
+    public function withOpenIssue()
+    {
+        return $this->afterCreating(function ($conference) {
+            ConferenceIssue::factory()
+                ->open()
+                ->create([
+                    'conference_id' => $conference->id,
+                ]);
+        });
+    }
+
     public function withClosedIssue()
     {
         return $this->afterCreating(function ($conference) {

--- a/database/factories/ConferenceIssueFactory.php
+++ b/database/factories/ConferenceIssueFactory.php
@@ -20,6 +20,15 @@ class ConferenceIssueFactory extends Factory
         ];
     }
 
+    public function open()
+    {
+        return $this->state(function () {
+            return [
+                'closed_at' => null,
+            ];
+        });
+    }
+
     public function closed()
     {
         return $this->state(function () {

--- a/database/factories/TalkFactory.php
+++ b/database/factories/TalkFactory.php
@@ -40,7 +40,7 @@ class TalkFactory extends Factory
     public function submitted()
     {
         return $this->afterCreating(function (Talk $talk) {
-            Conference::factory()->received($talk->current())->create();
+            Conference::factory()->received($talk->currentRevision())->create();
         });
     }
 

--- a/database/factories/TalkFactory.php
+++ b/database/factories/TalkFactory.php
@@ -40,7 +40,9 @@ class TalkFactory extends Factory
     public function submitted()
     {
         return $this->afterCreating(function (Talk $talk) {
-            Conference::factory()->received($talk->currentRevision())->create();
+            Conference::factory()
+                ->received($talk->loadCurrentRevision()->currentRevision)
+                ->create();
         });
     }
 

--- a/resources/views/account/public-profile/show.blade.php
+++ b/resources/views/account/public-profile/show.blade.php
@@ -34,11 +34,11 @@
         @forelse ($talks as $talk)
             <h4 class="text-2xl text-indigo">
                 <a href="{{ route('speakers-public.talks.show', ['profileSlug' => $user->profile_slug, 'talkId' => $talk->id]) }}">
-                    {{ $talk->currentRevision()->title }}
+                    {{ $talk->currentRevision->title }}
                 </a>
             </h4>
             <span class="text-sm text-gray-500">
-                {{ $talk->currentRevision()->length }}-minute {{ $talk->currentRevision()->type }} talk at {{ $talk->currentRevision()->level }} level
+                {{ $talk->currentRevision->length }}-minute {{ $talk->currentRevision->type }} talk at {{ $talk->currentRevision->level }} level
             </span>
         @empty
             This speaker has not made any of their talks public yet.

--- a/resources/views/account/public-profile/show.blade.php
+++ b/resources/views/account/public-profile/show.blade.php
@@ -34,11 +34,11 @@
         @forelse ($talks as $talk)
             <h4 class="text-2xl text-indigo">
                 <a href="{{ route('speakers-public.talks.show', ['profileSlug' => $user->profile_slug, 'talkId' => $talk->id]) }}">
-                    {{ $talk->current()->title }}
+                    {{ $talk->currentRevision()->title }}
                 </a>
             </h4>
             <span class="text-sm text-gray-500">
-                {{ $talk->current()->length }}-minute {{ $talk->current()->type }} talk at {{ $talk->current()->level }} level
+                {{ $talk->currentRevision()->length }}-minute {{ $talk->currentRevision()->type }} talk at {{ $talk->currentRevision()->level }} level
             </span>
         @empty
             This speaker has not made any of their talks public yet.

--- a/resources/views/talks/listing.blade.php
+++ b/resources/views/talks/listing.blade.php
@@ -1,4 +1,4 @@
-<x-listing :title="$talk->currentRevision()->title" :href="route('talks.show', $talk)">
+<x-listing :title="$talk->currentRevision->title" :href="route('talks.show', $talk)">
     <x-slot name="actions">
         <a href="{{ route('talks.edit', $talk) }}" title="Edit">
             @svg('compose', 'w-5 fill-current inline')
@@ -22,7 +22,7 @@
             <div>{{ $talk->created_at->toFormattedDateString() }}</div>
         </div>
         <div class="flex items-end">
-            <div>{{ $talk->currentRevision()->length }}-minute {{ $talk->currentRevision()->level }} {{ $talk->currentRevision()->type }}</div>
+            <div>{{ $talk->currentRevision->length }}-minute {{ $talk->currentRevision->level }} {{ $talk->currentRevision->type }}</div>
         </div>
     </x-slot>
 </x-listing>

--- a/resources/views/talks/listing.blade.php
+++ b/resources/views/talks/listing.blade.php
@@ -1,4 +1,4 @@
-<x-listing :title="$talk->current()->title" :href="route('talks.show', $talk)">
+<x-listing :title="$talk->currentRevision()->title" :href="route('talks.show', $talk)">
     <x-slot name="actions">
         <a href="{{ route('talks.edit', $talk) }}" title="Edit">
             @svg('compose', 'w-5 fill-current inline')
@@ -22,7 +22,7 @@
             <div>{{ $talk->created_at->toFormattedDateString() }}</div>
         </div>
         <div class="flex items-end">
-            <div>{{ $talk->current()->length }}-minute {{ $talk->current()->level }} {{ $talk->current()->type }}</div>
+            <div>{{ $talk->currentRevision()->length }}-minute {{ $talk->currentRevision()->level }} {{ $talk->currentRevision()->type }}</div>
         </div>
     </x-slot>
 </x-listing>

--- a/resources/views/talks/show-public.blade.php
+++ b/resources/views/talks/show-public.blade.php
@@ -11,15 +11,15 @@
         Return to profile for {{ $user->name }}
     </x-button.primary>
 
-    <h2 class="text-4xl mt-8">{{ $talk->current()->title }}</h2>
+    <h2 class="text-4xl mt-8">{{ $talk->currentRevision()->title }}</h2>
 
     <p style="font-style: italic;">
-        {{ $talk->current()->length }} minute {{ $talk->current()->level }} {{ $talk->current()->type }}
+        {{ $talk->currentRevision()->length }} minute {{ $talk->currentRevision()->level }} {{ $talk->currentRevision()->type }}
     </p>
 
     <h3 class="text-3xl mt-8">Description/Proposal</h3>
 
-    {!! markdown($talk->current()->getDescription()) !!}
+    {!! markdown($talk->currentRevision()->getDescription()) !!}
 </x-panel>
 
 @endsection

--- a/resources/views/talks/show-public.blade.php
+++ b/resources/views/talks/show-public.blade.php
@@ -11,15 +11,15 @@
         Return to profile for {{ $user->name }}
     </x-button.primary>
 
-    <h2 class="text-4xl mt-8">{{ $talk->currentRevision()->title }}</h2>
+    <h2 class="text-4xl mt-8">{{ $talk->currentRevision->title }}</h2>
 
     <p style="font-style: italic;">
-        {{ $talk->currentRevision()->length }} minute {{ $talk->currentRevision()->level }} {{ $talk->currentRevision()->type }}
+        {{ $talk->currentRevision->length }} minute {{ $talk->currentRevision->level }} {{ $talk->currentRevision->type }}
     </p>
 
     <h3 class="text-3xl mt-8">Description/Proposal</h3>
 
-    {!! markdown($talk->currentRevision()->getDescription()) !!}
+    {!! markdown($talk->currentRevision->getDescription()) !!}
 </x-panel>
 
 @endsection

--- a/resources/views/talks/show.blade.php
+++ b/resources/views/talks/show.blade.php
@@ -9,7 +9,7 @@
     <x-side-menu title="Revisions">
         <x-slot name="body">
             @foreach ($talk->revisions as $revision)
-                @if ($talk->current()->id == $revision->id)
+                @if ($talk->currentRevision()->id == $revision->id)
                     <a
                         href="/talks/{{ $talk->id }}"
                         class="{{ $baseLinkClasses }} {{ $revision->id == $current->id ? $activeLinkClasses : '' }}"

--- a/resources/views/talks/show.blade.php
+++ b/resources/views/talks/show.blade.php
@@ -9,7 +9,7 @@
     <x-side-menu title="Revisions">
         <x-slot name="body">
             @foreach ($talk->revisions as $revision)
-                @if ($talk->currentRevision()->id == $revision->id)
+                @if ($talk->currentRevision->id == $revision->id)
                     <a
                         href="/talks/{{ $talk->id }}"
                         class="{{ $baseLinkClasses }} {{ $revision->id == $current->id ? $activeLinkClasses : '' }}"

--- a/tests/Feature/ConferenceTest.php
+++ b/tests/Feature/ConferenceTest.php
@@ -1170,7 +1170,7 @@ class ConferenceTest extends TestCase
 
         $conference->reportIssue('spam', 'Conference has spam', $user);
 
-        $conference->load('openIssues');
+        $conference->loadCount('openIssues');
         $this->assertTrue($conference->isFlagged());
     }
 
@@ -1179,7 +1179,7 @@ class ConferenceTest extends TestCase
     {
         $conference = Conference::factory()->withClosedIssue()->create();
 
-        $conference->load('openIssues');
+        $conference->loadCount('openIssues');
         $this->assertFalse($conference->isFlagged());
     }
 
@@ -1267,5 +1267,39 @@ class ConferenceTest extends TestCase
 
         $this->assertFalse($conferenceA->shouldBeSearchable());
         $this->assertTrue($conferenceB->shouldBeSearchable());
+    }
+
+    /** @test */
+    public function conferences_with_open_issues_are_flagged_on_the_index_page(): void
+    {
+        $conference = Conference::factory()->withOpenIssue()->create();
+
+        $response = Livewire::test(ConferenceList::class);
+
+        tap($response->conferences->flatten(), function ($conferences) {
+            $this->assertEquals(1, $conferences->count());
+            $this->assertTrue($conferences->first()->isFlagged());
+        });
+    }
+
+    /** @test */
+    public function conferences_with_open_issues_are_flagged_on_the_show_page(): void
+    {
+        $conference = Conference::factory()->withOpenIssue()->create();
+
+        $response = $this->actingAs(User::factory()->create())
+            ->get(route('conferences.show', $conference));
+
+        $response->assertSee('An issue has been reported for this conference.');
+    }
+
+    /** @test */
+    public function conferences_with_open_issues_are_flagged_on_the_public_show_page(): void
+    {
+        $conference = Conference::factory()->withOpenIssue()->create();
+
+        $response = $this->get(route('conferences.show', $conference));
+
+        $response->assertSee('An issue has been reported for this conference.');
     }
 }

--- a/tests/Feature/ConferenceTest.php
+++ b/tests/Feature/ConferenceTest.php
@@ -1170,6 +1170,7 @@ class ConferenceTest extends TestCase
 
         $conference->reportIssue('spam', 'Conference has spam', $user);
 
+        $conference->load('openIssues');
         $this->assertTrue($conference->isFlagged());
     }
 
@@ -1178,6 +1179,7 @@ class ConferenceTest extends TestCase
     {
         $conference = Conference::factory()->withClosedIssue()->create();
 
+        $conference->load('openIssues');
         $this->assertFalse($conference->isFlagged());
     }
 

--- a/tests/Feature/PublicSpeakerProfileTest.php
+++ b/tests/Feature/PublicSpeakerProfileTest.php
@@ -354,7 +354,7 @@ class PublicSpeakerProfileTest extends TestCase
         $talk->revisions()->save($talkRevision);
 
         $this->get(route('speakers-public.show', [$user->profile_slug]))
-            ->assertDontSee($talk->current()->title);
+            ->assertDontSee($talk->currentRevision()->title);
     }
 
     /** @test */

--- a/tests/Feature/PublicSpeakerProfileTest.php
+++ b/tests/Feature/PublicSpeakerProfileTest.php
@@ -353,8 +353,10 @@ class PublicSpeakerProfileTest extends TestCase
         $talkRevision = TalkRevision::factory()->create();
         $talk->revisions()->save($talkRevision);
 
+        $talk->loadCurrentRevision();
+
         $this->get(route('speakers-public.show', [$user->profile_slug]))
-            ->assertDontSee($talk->currentRevision()->title);
+            ->assertDontSee($talk->currentRevision->title);
     }
 
     /** @test */

--- a/tests/Feature/TalkTest.php
+++ b/tests/Feature/TalkTest.php
@@ -79,8 +79,8 @@ class TalkTest extends TestCase
         $talk1 = Talk::factory()->author($user)->revised(['title' => 'zyxwv'])->create();
         $talk2 = Talk::factory()->author($user)->revised(['title' => 'abcde'])->create();
 
-        $this->assertEquals('abcde', $user->talks->sortByTitle()->first()->current()->title);
-        $this->assertEquals('zyxwv', $user->talks->sortByTitle()->last()->current()->title);
+        $this->assertEquals('abcde', $user->talks->sortByTitle()->first()->currentRevision()->title);
+        $this->assertEquals('zyxwv', $user->talks->sortByTitle()->last()->currentRevision()->title);
     }
 
     /** @test */
@@ -224,7 +224,7 @@ class TalkTest extends TestCase
             ]);
 
         $this->actingAs($user)
-            ->put("/talks/{$talk->id}", array_merge($talk->current()->toArray(), [
+            ->put("/talks/{$talk->id}", array_merge($talk->currentRevision()->toArray(), [
                 'title' => 'New',
                 'public' => '1',
             ]));
@@ -232,7 +232,7 @@ class TalkTest extends TestCase
         $talk = Talk::first();
 
         $this->assertTrue($talk->public);
-        $this->assertEquals('New', $talk->current()->title);
+        $this->assertEquals('New', $talk->currentRevision()->title);
         $this->assertEquals('old title', $talk->revisions->last()->title);
     }
 
@@ -262,7 +262,7 @@ class TalkTest extends TestCase
         $talk = Talk::factory()->author($user)->create();
 
         $response = $this->actingAs($user)
-            ->put("/talks/{$talk->id}", array_merge($talk->current()->toArray(), [
+            ->put("/talks/{$talk->id}", array_merge($talk->currentRevision()->toArray(), [
                 'length' => 'invalid',
             ]));
 
@@ -276,7 +276,7 @@ class TalkTest extends TestCase
         $talk = Talk::factory()->author($user)->create();
 
         $response = $this->actingAs($user)
-            ->put("/talks/{$talk->id}", array_merge($talk->current()->toArray(), [
+            ->put("/talks/{$talk->id}", array_merge($talk->currentRevision()->toArray(), [
                 'slides' => 'invalid url',
             ]));
 

--- a/tests/Feature/TalkTest.php
+++ b/tests/Feature/TalkTest.php
@@ -79,8 +79,10 @@ class TalkTest extends TestCase
         $talk1 = Talk::factory()->author($user)->revised(['title' => 'zyxwv'])->create();
         $talk2 = Talk::factory()->author($user)->revised(['title' => 'abcde'])->create();
 
-        $this->assertEquals('abcde', $user->talks->sortByTitle()->first()->currentRevision()->title);
-        $this->assertEquals('zyxwv', $user->talks->sortByTitle()->last()->currentRevision()->title);
+        $talks = $user->talks()->withCurrentRevision()->get();
+
+        $this->assertEquals('abcde', $talks->sortByTitle()->first()->currentRevision->title);
+        $this->assertEquals('zyxwv', $talks->sortByTitle()->last()->currentRevision->title);
     }
 
     /** @test */
@@ -224,7 +226,7 @@ class TalkTest extends TestCase
             ]);
 
         $this->actingAs($user)
-            ->put("/talks/{$talk->id}", array_merge($talk->currentRevision()->toArray(), [
+            ->put("/talks/{$talk->id}", array_merge($talk->loadCurrentRevision()->currentRevision->toArray(), [
                 'title' => 'New',
                 'public' => '1',
             ]));
@@ -232,7 +234,7 @@ class TalkTest extends TestCase
         $talk = Talk::first();
 
         $this->assertTrue($talk->public);
-        $this->assertEquals('New', $talk->currentRevision()->title);
+        $this->assertEquals('New', $talk->loadCurrentRevision()->currentRevision->title);
         $this->assertEquals('old title', $talk->revisions->last()->title);
     }
 
@@ -262,7 +264,7 @@ class TalkTest extends TestCase
         $talk = Talk::factory()->author($user)->create();
 
         $response = $this->actingAs($user)
-            ->put("/talks/{$talk->id}", array_merge($talk->currentRevision()->toArray(), [
+            ->put("/talks/{$talk->id}", array_merge($talk->loadCurrentRevision()->currentRevision->toArray(), [
                 'length' => 'invalid',
             ]));
 
@@ -276,7 +278,7 @@ class TalkTest extends TestCase
         $talk = Talk::factory()->author($user)->create();
 
         $response = $this->actingAs($user)
-            ->put("/talks/{$talk->id}", array_merge($talk->currentRevision()->toArray(), [
+            ->put("/talks/{$talk->id}", array_merge($talk->loadCurrentRevision()->currentRevision->toArray(), [
                 'slides' => 'invalid url',
             ]));
 

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -60,13 +60,13 @@ class UserTest extends TestCase
         $conference = Conference::factory()->create();
 
         $conference->submissions()->create([
-            'talk_revision_id' => $talk->currentRevision()->id,
+            'talk_revision_id' => $talk->loadCurrentRevision()->currentRevision->id,
         ]);
 
         $this->assertEquals(1, $user->talkRevisions()->count());
         $this->assertEquals(1, $user->submissions()->count());
         $this->assertEquals(
-            $talk->currentRevision()->id,
+            $talk->currentRevision->id,
             $user->submissions->first()->talk_revision_id,
         );
     }

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -60,13 +60,13 @@ class UserTest extends TestCase
         $conference = Conference::factory()->create();
 
         $conference->submissions()->create([
-            'talk_revision_id' => $talk->current()->id,
+            'talk_revision_id' => $talk->currentRevision()->id,
         ]);
 
         $this->assertEquals(1, $user->talkRevisions()->count());
         $this->assertEquals(1, $user->submissions()->count());
         $this->assertEquals(
-            $talk->current()->id,
+            $talk->currentRevision()->id,
             $user->submissions->first()->talk_revision_id,
         );
     }


### PR DESCRIPTION
This PR removes n+1 queries with the following solutions:
- The count of open issues is now being loaded on the conferences index and show pages
- Submissions are now loaded on the conferences index page
- Each talk's current revision is now loaded on the conferences index and show pages
- The talk of the current revision is set as a relation on the conference show page

This results in the following query count reduction when testing locally:

| Page | Before | After |
| - | - | - |
| Conference list | 80 | 1 |
| Conference show | 2 | 2 |
| Conference list (auth) | 163 | 6 |
| Conference show | 125 | 7 |