### PR TITLE
Load current revision for talk.edit route

### DIFF
--- a/app/Http/Controllers/TalksController.php
+++ b/app/Http/Controllers/TalksController.php
@@ -64,7 +64,7 @@ class TalksController extends Controller
     public function edit($id)
     {
         try {
-            $talk = auth()->user()->talks()->findOrFail($id);
+            $talk = auth()->user()->talks()->withCurrentRevision()->findOrFail($id);
         } catch (Exception $e) {
             Session::flash('error-message', 'Sorry, but that isn\'t a valid URL.');
             Log::error($e);

--- a/tests/Feature/TalkTest.php
+++ b/tests/Feature/TalkTest.php
@@ -360,4 +360,15 @@ class TalkTest extends TestCase
         $response->assertRedirect('talks');
         $this->assertDatabaseMissing('talks', ['id' => $talk->id]);
     }
+
+    /** @test */
+    public function editing_a_talk(): void
+    {
+        $talk = Talk::factory()->create();
+
+        $response = $this->actingAs($talk->author)
+            ->get(route('talks.edit', $talk));
+
+        $response->assertSuccessful();
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where the `talks.edit` route could not be visited because the `currentRevision` relationship was not loaded on the `Talk` object.