### PR TITLE
Fix CSS build

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,9 +1,9 @@
+@import "./calendar";
+@import "./mobile-menu-button";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import "./calendar";
-@import "./mobile-menu-button";
 
 [v-cloak] {
     display: none;


### PR DESCRIPTION
This PR imports CSS files before Tailwind imports to fix an error in the `npm run prod` script.