### PR TITLE
Display locations on conference list

### DIFF
--- a/app/CallingAllPapers/ConferenceImporter.php
+++ b/app/CallingAllPapers/ConferenceImporter.php
@@ -73,8 +73,8 @@ class ConferenceImporter
             ->firstOrNew(['calling_all_papers_id' => $event->id]);
         $this->updateConferenceFromCallingAllPapersEvent($conference, $event);
 
-        if (! $conference->latitude && ! $conference->longitude && $conference->location) {
-            $this->geocodeLatLongFromLocation($conference);
+        if ($conference->location) {
+            $this->geocodeLocation($conference);
         }
 
         if ($validator->fails()) {
@@ -112,14 +112,18 @@ class ConferenceImporter
         return (float) $primary && (float) $secondary ? $primary : null;
     }
 
-    private function geocodeLatLongFromLocation(Conference $conference): Conference
+    private function geocodeLocation(Conference $conference): void
     {
         try {
             $result = $this->geocoder->geocode($conference->location);
-            $conference->coordinates = $result->getCoordinates();
         } catch (InvalidAddressGeocodingException $e) {
+            return;
         }
 
-        return $conference;
+        if (! $conference->latitude && ! $conference->longitude) {
+            $conference->coordinates = $result->getCoordinates();
+        }
+
+        $conference->location_name = $result->getLocationName();
     }
 }

--- a/app/CallingAllPapers/ConferenceImporter.php
+++ b/app/CallingAllPapers/ConferenceImporter.php
@@ -115,7 +115,8 @@ class ConferenceImporter
     private function geocodeLatLongFromLocation(Conference $conference): Conference
     {
         try {
-            $conference->coordinates = $this->geocoder->geocode($conference->location);
+            $result = $this->geocoder->geocode($conference->location);
+            $conference->coordinates = $result->getCoordinates();
         } catch (InvalidAddressGeocodingException $e) {
         }
 

--- a/app/CallingAllPapers/ConferenceImporter.php
+++ b/app/CallingAllPapers/ConferenceImporter.php
@@ -73,7 +73,7 @@ class ConferenceImporter
             ->firstOrNew(['calling_all_papers_id' => $event->id]);
         $this->updateConferenceFromCallingAllPapersEvent($conference, $event);
 
-        if ($conference->location) {
+        if (! $conference->latitude && ! $conference->longitude && $conference->location) {
             $this->geocodeLocation($conference);
         }
 
@@ -120,10 +120,7 @@ class ConferenceImporter
             return;
         }
 
-        if (! $conference->latitude && ! $conference->longitude) {
-            $conference->coordinates = $result->getCoordinates();
-        }
-
+        $conference->coordinates = $result->getCoordinates();
         $conference->location_name = $result->getLocationName();
     }
 }

--- a/app/CallingAllPapers/ConferenceImporter.php
+++ b/app/CallingAllPapers/ConferenceImporter.php
@@ -4,7 +4,7 @@ namespace App\CallingAllPapers;
 
 use App\Exceptions\InvalidAddressGeocodingException;
 use App\Models\Conference;
-use App\Services\Geocoder;
+use App\Services\Geocoder\Geocoder;
 use Carbon\Carbon;
 use Carbon\Exceptions\InvalidFormatException;
 use DateTime;

--- a/app/Console/Commands/BackfillConferenceLocationNames.php
+++ b/app/Console/Commands/BackfillConferenceLocationNames.php
@@ -31,7 +31,5 @@ class BackfillConferenceLocationNames extends Command
             $conference->location_name = $result->getLocationName();
             $conference->save();
         });
-
-        dd($conferences->count());
     }
 }

--- a/app/Console/Commands/BackfillConferenceLocationNames.php
+++ b/app/Console/Commands/BackfillConferenceLocationNames.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Exceptions\InvalidAddressGeocodingException;
+use App\Models\Conference;
+use App\Services\Geocoder;
+use Illuminate\Console\Command;
+
+class BackfillConferenceLocationNames extends Command
+{
+    protected $signature = 'app:backfill-conference-location-names';
+
+    protected $description = 'Command description';
+
+    public function handle()
+    {
+        $conferences = Conference::query()
+            ->whereAfter(now())
+            ->whereNotNull(['latitude', 'longitude'])
+            ->whereNull('location_name')
+            ->get();
+
+        $conferences->each(function ($conference) {
+            try {
+                $result = app(Geocoder::class)->geocode($conference->location);
+            } catch (InvalidAddressGeocodingException $e) {
+                return;
+            }
+
+            $conference->location_name = $result->getLocationName();
+            $conference->save();
+        });
+
+        dd($conferences->count());
+    }
+}

--- a/app/Console/Commands/BackfillConferenceLocationNames.php
+++ b/app/Console/Commands/BackfillConferenceLocationNames.php
@@ -4,7 +4,7 @@ namespace App\Console\Commands;
 
 use App\Exceptions\InvalidAddressGeocodingException;
 use App\Models\Conference;
-use App\Services\Geocoder;
+use App\Services\Geocoder\Geocoder;
 use Illuminate\Console\Command;
 
 class BackfillConferenceLocationNames extends Command

--- a/app/Console/Commands/BackfillConferenceLocationNames.php
+++ b/app/Console/Commands/BackfillConferenceLocationNames.php
@@ -11,7 +11,7 @@ class BackfillConferenceLocationNames extends Command
 {
     protected $signature = 'app:backfill-conference-location-names';
 
-    protected $description = 'Command description';
+    protected $description = 'Backfill location names for future conferences';
 
     public function handle()
     {

--- a/app/Http/Requests/SaveConferenceRequest.php
+++ b/app/Http/Requests/SaveConferenceRequest.php
@@ -38,6 +38,7 @@ class SaveConferenceRequest extends FormRequest
                 'before:starts_at',
             ],
             'location' => ['nullable'],
+            'location_name' => ['nullable'],
             'latitude' => ['nullable'],
             'longitude' => ['nullable'],
             'speaker_package' => ['nullable'],

--- a/app/Models/Conference.php
+++ b/app/Models/Conference.php
@@ -32,6 +32,7 @@ class Conference extends UuidBase
         'author_id',
         'title',
         'location',
+        'location_name',
         'latitude',
         'longitude',
         'description',

--- a/app/Services/Geocoder.php
+++ b/app/Services/Geocoder.php
@@ -8,24 +8,32 @@ use Illuminate\Support\Facades\Http;
 
 class Geocoder
 {
-    public function geocode(string $address): Coordinates
+    private $response;
+
+    public function geocode(string $address): self
     {
         if ($this->isInvalidAddress($address)) {
             throw new InvalidAddressGeocodingException;
         }
 
-        $response = $this->requestGeocoding($address);
+        $this->response = $this->requestGeocoding($address);
 
-        if (! count($response['results'])) {
+        if (! count($this->response['results'])) {
             cache()->set('invalid-address::' . md5($address), true);
             throw new InvalidAddressGeocodingException;
         }
 
+        return $this;
+    }
+
+    public function getCoordinates(): Coordinates
+    {
         return new Coordinates(
-            $this->getCoordinate('lat', $response),
-            $this->getCoordinate('lng', $response),
+            $this->getCoordinate('lat', $this->response),
+            $this->getCoordinate('lng', $this->response),
         );
     }
+
 
     private function requestGeocoding($address)
     {

--- a/app/Services/Geocoder.php
+++ b/app/Services/Geocoder.php
@@ -29,8 +29,8 @@ class Geocoder
     public function getCoordinates(): Coordinates
     {
         return new Coordinates(
-            $this->getCoordinate('lat', $this->response),
-            $this->getCoordinate('lng', $this->response),
+            $this->getCoordinate('lat'),
+            $this->getCoordinate('lng'),
         );
     }
 
@@ -60,9 +60,9 @@ class Geocoder
             ->json();
     }
 
-    private function getCoordinate($type, $response)
+    private function getCoordinate($type)
     {
-        return data_get($response, "results.0.geometry.location.{$type}");
+        return data_get($this->response, "results.0.geometry.location.{$type}");
     }
 
     private function getCity()

--- a/app/Services/Geocoder.php
+++ b/app/Services/Geocoder.php
@@ -39,12 +39,11 @@ class Geocoder
         $country = $this->getCountry();
         $city = $this->getCity();
 
-        if ($country === 'United States') {
-            $state = $this->getState();
-            return "{$city}, {$state}, {$country}";
-        }
+        $values = $country === 'United States'
+            ? [$city, $this->getState(), $country]
+            : [$city, $country];
 
-        return "{$city}, {$country}";
+        return collect($values)->filter()->implode(', ');
     }
 
     private function requestGeocoding($address)
@@ -67,17 +66,17 @@ class Geocoder
 
     private function getCity()
     {
-        return $this->getAddressComponent(['locality', 'postal_town'])['long_name'] ?? '';
+        return $this->getAddressComponent(['locality', 'postal_town'])['long_name'] ?? null;
     }
 
     private function getState()
     {
-        return $this->getAddressComponent(['administrative_area_level_1'])['short_name'] ?? '';
+        return $this->getAddressComponent(['administrative_area_level_1'])['short_name'] ?? null;
     }
 
     private function getCountry()
     {
-        return $this->getAddressComponent(['country'])['long_name'] ?? '';
+        return $this->getAddressComponent(['country'])['long_name'] ?? null;
     }
 
     private function getAddressComponent(array $types)

--- a/app/Services/Geocoder/Geocoder.php
+++ b/app/Services/Geocoder/Geocoder.php
@@ -3,7 +3,6 @@
 namespace App\Services\Geocoder;
 
 use App\Exceptions\InvalidAddressGeocodingException;
-use App\Services\Geocoder\GeocoderResponse;
 use Illuminate\Support\Facades\Http;
 
 class Geocoder

--- a/app/Services/Geocoder/Geocoder.php
+++ b/app/Services/Geocoder/Geocoder.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Services\Geocoder;
+
+use App\Exceptions\InvalidAddressGeocodingException;
+use App\Services\Geocoder\GeocoderResponse;
+use Illuminate\Support\Facades\Http;
+
+class Geocoder
+{
+    public function geocode(string $address): GeocoderResponse
+    {
+        if ($this->isInvalidAddress($address)) {
+            throw new InvalidAddressGeocodingException;
+        }
+
+        return $this->requestGeocoding($address);
+    }
+
+    private function requestGeocoding($address)
+    {
+        $response = Http::acceptJson()
+            ->withHeaders([
+                'User-Agent' => 'Symposium CLI',
+            ])
+            ->get('https://maps.googleapis.com/maps/api/geocode/json', [
+                'address' => $address,
+                'key' => config('services.google.maps.key'),
+            ])
+            ->json();
+
+        if (! count($response['results'])) {
+            cache()->set('invalid-address::' . md5($address), true);
+            throw new InvalidAddressGeocodingException;
+        }
+
+        return new GeocoderResponse($response);
+    }
+
+    private function isInvalidAddress($address)
+    {
+        return cache('invalid-address::' . md5($address));
+    }
+}

--- a/app/Services/Geocoder/GeocoderResponse.php
+++ b/app/Services/Geocoder/GeocoderResponse.php
@@ -6,9 +6,7 @@ use App\Casts\Coordinates;
 
 class GeocoderResponse
 {
-    public function __construct(protected $response)
-    {
-    }
+    public function __construct(protected $response) {}
 
     public function getCoordinates(): Coordinates
     {

--- a/app/Services/Geocoder/GeocoderResponse.php
+++ b/app/Services/Geocoder/GeocoderResponse.php
@@ -1,29 +1,13 @@
 <?php
 
-namespace App\Services;
+namespace App\Services\Geocoder;
 
 use App\Casts\Coordinates;
-use App\Exceptions\InvalidAddressGeocodingException;
-use Illuminate\Support\Facades\Http;
 
-class Geocoder
+class GeocoderResponse
 {
-    private $response;
-
-    public function geocode(string $address): self
+    public function __construct(protected $response)
     {
-        if ($this->isInvalidAddress($address)) {
-            throw new InvalidAddressGeocodingException;
-        }
-
-        $this->response = $this->requestGeocoding($address);
-
-        if (! count($this->response['results'])) {
-            cache()->set('invalid-address::' . md5($address), true);
-            throw new InvalidAddressGeocodingException;
-        }
-
-        return $this;
     }
 
     public function getCoordinates(): Coordinates
@@ -44,19 +28,6 @@ class Geocoder
             : [$city, $country];
 
         return collect($values)->filter()->implode(', ');
-    }
-
-    private function requestGeocoding($address)
-    {
-        return Http::acceptJson()
-            ->withHeaders([
-                'User-Agent' => 'Symposium CLI',
-            ])
-            ->get('https://maps.googleapis.com/maps/api/geocode/json', [
-                'address' => $address,
-                'key' => config('services.google.maps.key'),
-            ])
-            ->json();
     }
 
     private function getCoordinate($type)
@@ -83,10 +54,5 @@ class Geocoder
     {
         return collect(data_get($this->response, 'results.0.address_components', []))
             ->firstWhere(fn ($component) => collect($component['types'])->intersect($types)->isNotEmpty());
-    }
-
-    private function isInvalidAddress($address)
-    {
-        return cache('invalid-address::' . md5($address));
     }
 }

--- a/database/migrations/2024_12_20_115249_add_location_name_to_conferences_table.php
+++ b/database/migrations/2024_12_20_115249_add_location_name_to_conferences_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('conferences', function (Blueprint $table) {
+            $table->string('location_name')->nullable()->after('location');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('conferences', function (Blueprint $table) {
+            $table->dropColumn('location_name');
+        });
+    }
+};

--- a/resources/js/components/LocationLookup.vue
+++ b/resources/js/components/LocationLookup.vue
@@ -3,6 +3,7 @@
         <slot :lookup="lookup" @keydown.enter.prevent></slot>
         <input type="hidden" name="latitude" v-model="latitude">
         <input type="hidden" name="longitude" v-model="longitude">
+        <input type="hidden" name="location_name" v-model="locationName">
     </div>
 </template>
 
@@ -13,6 +14,7 @@ export default {
         return {
             latitude: '',
             longitude: '',
+            locationName: '',
         };
     },
     methods: {
@@ -25,9 +27,31 @@ export default {
 
             dropdown.addListener('place_changed', () => {
                 const place = dropdown.getPlace();
+
                 this.latitude = place.geometry.location.lat();
                 this.longitude = place.geometry.location.lng();
+                this.locationName = this.getLocationName(place.address_components);
             });
+        },
+        getLocationName(components) {
+            const country = components.find(component => {
+                return component.types.includes('country');
+            })?.long_name;
+            const city = components.find(component => {
+                return component.types.includes('locality') ||
+                    component.types.includes('postal_town');
+            })?.long_name;
+
+            const values = country === 'United States'
+                ? [city, this.getState(components), country]
+                : [city, country];
+
+            return values.filter(v => v).join(', ');
+        },
+        getState(components) {
+            return components.find(component => {
+                return component.types.includes('administrative_area_level_1');
+            })?.short_name;
         },
     },
 };

--- a/resources/views/conferences/listing.blade.php
+++ b/resources/views/conferences/listing.blade.php
@@ -64,6 +64,11 @@
             @endif
         </div>
     </div>
+    @if ($conference->location_name || $conference->location)
+        <div class="pl-8 text-gray-500">
+            {{ $conference->location_name ?? $conference->location }}
+        </div>
+    @endif
     <div class="mt-4 pl-8 space-y-3">
         <x-info icon="calendar" icon-color="text-gray-400">
             <span class="text-gray-400">Dates:</span>

--- a/tests/Feature/CallingAllPapersConferenceImporterTest.php
+++ b/tests/Feature/CallingAllPapersConferenceImporterTest.php
@@ -238,7 +238,8 @@ class CallingAllPapersConferenceImporterTest extends TestCase
             $mock->shouldReceive('geocode')
                 ->andReturn($mock)
                 ->shouldReceive('getCoordinates')
-                ->andReturn(new Coordinates('38.8921062', '-77.0259036'));
+                ->andReturn(new Coordinates('38.8921062', '-77.0259036'))
+                ->shouldReceive('getLocationName');
         });
 
         $importer = new ConferenceImporter(1);
@@ -248,6 +249,33 @@ class CallingAllPapersConferenceImporterTest extends TestCase
 
         $this->assertEquals('38.8921062', $conference->latitude);
         $this->assertEquals('-77.0259036', $conference->longitude);
+    }
+
+    #[Test]
+    public function it_fills_location_name(): void
+    {
+        $event = $this->eventStub;
+
+        $event->latitude = '0';
+        $event->longitude = '-82.682221';
+        $event->location = '10th St. & Constitution Ave. NW, Washington, DC';
+
+        $this->mockClient($event);
+        $this->mock(Geocoder::class, function ($mock) {
+            $mock->shouldReceive('geocode')
+                ->andReturn($mock)
+                ->shouldReceive('getCoordinates')
+                ->andReturn(new Coordinates('38.8921062', '-77.0259036'))
+                ->shouldReceive('getLocationName')
+                ->andReturn('Göteborg, Sweden');
+        });
+
+        $importer = new ConferenceImporter(1);
+        $importer->import($event);
+
+        $conference = Conference::first();
+
+        $this->assertEquals('Göteborg, Sweden', $conference->location_name);
     }
 
     #[Test]

--- a/tests/Feature/CallingAllPapersConferenceImporterTest.php
+++ b/tests/Feature/CallingAllPapersConferenceImporterTest.php
@@ -236,6 +236,8 @@ class CallingAllPapersConferenceImporterTest extends TestCase
         $this->mockClient($event);
         $this->mock(Geocoder::class, function ($mock) {
             $mock->shouldReceive('geocode')
+                ->andReturn($mock)
+                ->shouldReceive('getCoordinates')
                 ->andReturn(new Coordinates('38.8921062', '-77.0259036'));
         });
 

--- a/tests/Feature/CallingAllPapersConferenceImporterTest.php
+++ b/tests/Feature/CallingAllPapersConferenceImporterTest.php
@@ -468,4 +468,22 @@ class CallingAllPapersConferenceImporterTest extends TestCase
 
         $this->assertEquals(1, Conference::count());
     }
+
+    #[Test]
+    public function the_geocoder_is_not_called_for_conferences_already_having_coordinates(): void
+    {
+        $this->mockClient();
+        $spy = $this->spy(Geocoder::class);
+
+        $importer = new ConferenceImporter(1);
+        $event = $this->eventStub;
+        $event->location = 'Somewhere';
+        $event->latitude = 123;
+        $event->longitude = 321;
+
+        $importer->import($event);
+
+        $spy->shouldNotHaveReceived('geocode');
+        $this->assertEquals(1, Conference::count());
+    }
 }

--- a/tests/Feature/CallingAllPapersConferenceImporterTest.php
+++ b/tests/Feature/CallingAllPapersConferenceImporterTest.php
@@ -6,7 +6,8 @@ use App\CallingAllPapers\ConferenceImporter;
 use App\Casts\Coordinates;
 use App\Exceptions\InvalidAddressGeocodingException;
 use App\Models\Conference;
-use App\Services\Geocoder;
+use App\Services\Geocoder\Geocoder;
+use App\Services\Geocoder\GeocoderResponse;
 use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\MocksCallingAllPapers;
@@ -234,12 +235,14 @@ class CallingAllPapersConferenceImporterTest extends TestCase
         $event->location = '10th St. & Constitution Ave. NW, Washington, DC';
 
         $this->mockClient($event);
-        $this->mock(Geocoder::class, function ($mock) {
-            $mock->shouldReceive('geocode')
-                ->andReturn($mock)
-                ->shouldReceive('getCoordinates')
+        $response = $this->mock(GeocoderResponse::class, function ($mock) {
+            $mock->shouldReceive('getCoordinates')
                 ->andReturn(new Coordinates('38.8921062', '-77.0259036'))
                 ->shouldReceive('getLocationName');
+        });
+        $this->mock(Geocoder::class, function ($mock) use ($response) {
+            $mock->shouldReceive('geocode')
+                ->andReturn($response);
         });
 
         $importer = new ConferenceImporter(1);
@@ -261,13 +264,15 @@ class CallingAllPapersConferenceImporterTest extends TestCase
         $event->location = '10th St. & Constitution Ave. NW, Washington, DC';
 
         $this->mockClient($event);
-        $this->mock(Geocoder::class, function ($mock) {
-            $mock->shouldReceive('geocode')
-                ->andReturn($mock)
-                ->shouldReceive('getCoordinates')
+        $response = $this->mock(GeocoderResponse::class, function ($mock) {
+            $mock->shouldReceive('getCoordinates')
                 ->andReturn(new Coordinates('38.8921062', '-77.0259036'))
                 ->shouldReceive('getLocationName')
                 ->andReturn('Göteborg, Sweden');
+        });
+        $this->mock(Geocoder::class, function ($mock) use ($response) {
+            $mock->shouldReceive('geocode')
+                ->andReturn($response);
         });
 
         $importer = new ConferenceImporter(1);

--- a/tests/Feature/ConferenceTest.php
+++ b/tests/Feature/ConferenceTest.php
@@ -32,7 +32,7 @@ class ConferenceTest extends TestCase
     }
 
     #[Test]
-    public function a_conference_can_include_location_coordinates(): void
+    public function a_conference_can_include_location_coordinates_and_name(): void
     {
         $user = User::factory()->create();
 
@@ -43,6 +43,7 @@ class ConferenceTest extends TestCase
                 'url' => 'https://jedicon.com',
                 'latitude' => '37.7991531',
                 'longitude' => '-122.45050129999998',
+                'location_name' => 'San Francisco, CA, United States',
             ]);
 
         $this->assertDatabaseHas(Conference::class, [
@@ -51,6 +52,7 @@ class ConferenceTest extends TestCase
             'url' => 'https://jedicon.com',
             'latitude' => '37.7991531',
             'longitude' => '-122.45050129999998',
+            'location_name' => 'San Francisco, CA, United States',
         ]);
     }
 

--- a/tests/Integration/GeocoderTest.php
+++ b/tests/Integration/GeocoderTest.php
@@ -3,7 +3,7 @@
 namespace Tests\Feature;
 
 use App\Exceptions\InvalidAddressGeocodingException;
-use App\Services\Geocoder;
+use App\Services\Geocoder\Geocoder;
 use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;

--- a/tests/Integration/GeocoderTest.php
+++ b/tests/Integration/GeocoderTest.php
@@ -17,7 +17,8 @@ class GeocoderTest extends TestCase
 
         $geocoder = app(Geocoder::class);
 
-        $coordinates = $geocoder->geocode('1600 Pennsylvania Ave Washington, DC');
+        $result = $geocoder->geocode('1600 Pennsylvania Ave Washington, DC');
+        $coordinates = $result->getCoordinates();
 
         $this->assertEquals('38.8976801', $coordinates->getLatitude());
         $this->assertEquals('-77.0363304', $coordinates->getLongitude());

--- a/tests/Integration/GeocoderTest.php
+++ b/tests/Integration/GeocoderTest.php
@@ -63,4 +63,30 @@ class GeocoderTest extends TestCase
 
         $this->fail('An exception was expected but not thrown');
     }
+
+    #[Test]
+    public function formatting_a_us_location_name(): void
+    {
+        $geocoder = app(Geocoder::class);
+
+        $result = $geocoder->geocode('1600 Pennsylvania Ave Washington, DC');
+
+        $this->assertEquals(
+            'Washington, DC, United States',
+            $result->getLocationName(),
+        );
+    }
+
+    #[Test]
+    public function formatting_a_non_us_location_name(): void
+    {
+        $geocoder = app(Geocoder::class);
+
+        $result = $geocoder->geocode('Kungsgatan 5, 411 19, Göteborg');
+
+        $this->assertEquals(
+            'Göteborg, Sweden',
+            $result->getLocationName(),
+        );
+    }
 }


### PR DESCRIPTION
This PR closes #519 by adding the conference location to the conferences list page. This PR also adds a `app:backfill-conference-location-names` to backfill a display-friendly conference location. Each conference listing will then display either the conference's location name, or the value in the `location` column, if present.

<img width="482" alt="image" src="https://github.com/user-attachments/assets/ffc54ed7-77ad-4105-b090-8bf88739d35a" />
