### PR TITLE
Fix viewing talk revisions

### DIFF
--- a/app/Http/Controllers/TalksController.php
+++ b/app/Http/Controllers/TalksController.php
@@ -65,9 +65,11 @@ class TalksController extends Controller
 
     public function show($id, Request $request): View
     {
-        $talk = auth()->user()->talks()->findOrFail($id);
+        $talk = auth()->user()->talks()->findOrFail($id)->loadCurrentRevision();
 
-        $current = $request->filled('revision') ? $talk->revisions()->findOrFail($request->input('revision')) : $talk->loadCurrentRevision()->currentRevision;
+        $current = $request->filled('revision')
+            ? $talk->revisions()->findOrFail($request->input('revision'))
+            : $talk->currentRevision;
 
         $submissions = Submission::where('talk_revision_id', $current->id)
             ->with(['conference', 'acceptance', 'rejection'])

--- a/tests/Feature/TalkTest.php
+++ b/tests/Feature/TalkTest.php
@@ -74,6 +74,26 @@ class TalkTest extends TestCase
     }
 
     #[Test]
+    public function viewing_a_talk_revision(): void
+    {
+        $user = User::factory()->create();
+        Conference::factory()->create();
+        $talk = Talk::factory()->author($user)->create();
+
+        $firstDraft = TalkRevision::factory()->create(['title' => 'First Draft']);
+        $talk->revisions()->save($firstDraft);
+
+        $current = TalkRevision::factory()->create(['title' => 'Final Talk']);
+        $talk->revisions()->save($current);
+
+        $response = $this->actingAs($user)
+            ->get("talks/{$talk->id}?revision=" . $firstDraft->id);
+
+        $response->assertSuccessful();
+        $response->assertSee('First Draft');
+    }
+
+    #[Test]
     public function user_talks_are_sorted_alphabetically(): void
     {
         $user = User::factory()->create();


### PR DESCRIPTION
This PR fixes an issue on the `talks.show` page where viewing a talk revision would result in an error due to the current talk revision not being loaded.